### PR TITLE
Fix paging for okta_application. Fixes #10

### DIFF
--- a/okta/table_okta_application.go
+++ b/okta/table_okta_application.go
@@ -65,7 +65,7 @@ func listOktaApplications(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	logger := plugin.Logger(ctx)
 	client, err := Connect(ctx, d)
 	if err != nil {
-		logger.Error("listOktaUsers", "connect", err)
+		logger.Error("listOktaApplications", "connect", err)
 		return nil, err
 	}
 
@@ -101,7 +101,7 @@ func listOktaApplications(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 
 	// paging
 	for resp.HasNextPage() {
-		var nextApplicationSet []*okta.App
+		var nextApplicationSet []*okta.Application
 		resp, err = resp.Next(ctx, &nextApplicationSet)
 		if err != nil {
 			logger.Error("listOktaApplications", "list application paging", err)


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
Tested with keeping limit as 2
```
➜  steampipe-plugin-okta git:(main) ✗ steampipe query
Welcome to Steampipe v0.7.2
For more information, type .help
> select * from okta_application

Error: json: cannot unmarshal object into Go value of type okta.App


Time: 2.464257589s
+---------------------+----------------------+---------------------+---------------------+--------+---------------------+--------+----------------+---------------------------------------------------------
| name                | id                   | label               | created             | filter | last_updated        | status | sign_on_mode   | settings                                                
+---------------------+----------------------+---------------------+---------------------+--------+---------------------+--------+----------------+---------------------------------------------------------
| okta_browser_plugin | 0oa1e5eiy5lYpLrqW5d7 | Okta Browser Plugin | 2021-08-02 10:57:03 | <null> | 2021-08-02 10:57:03 | ACTIVE | OPENID_CONNECT | {"app":{},"notifications":{"vpn":{"network":{"connection
| saasure             | 0oa1e5a95pRTw0D6p5d7 | Okta Admin Console  | 2021-08-02 10:56:58 | <null> | 2021-08-02 10:56:58 | ACTIVE | OPENID_CONNECT | {"app":{},"notifications":{"vpn":{"network":{"connection
+---------------------+----------------------+---------------------+---------------------+--------+---------------------+--------+----------------+---------------------------------------------------------
> .quit
➜  steampipe-plugin-okta git:(main) ✗ make
go build -o ~/.steampipe/plugins/hub.steampipe.io/plugins/turbot/okta@latest/steampipe-plugin-okta.plugin *.go
➜  steampipe-plugin-okta git:(main) ✗ steampipe query
Welcome to Steampipe v0.7.2
For more information, type .help
> select * from okta_application

Time: 3.3878458s
+---------------------------+----------------------+----------------------+---------------------+--------+---------------------+--------+----------------+--------------------------------------------------
| name                      | id                   | label                | created             | filter | last_updated        | status | sign_on_mode   | settings                                         
+---------------------------+----------------------+----------------------+---------------------+--------+---------------------+--------+----------------+--------------------------------------------------
| saasure                   | 0oa1e5a95pRTw0D6p5d7 | Okta Admin Console   | 2021-08-02 10:56:58 | <null> | 2021-08-02 10:56:58 | ACTIVE | OPENID_CONNECT | {"app":{},"notifications":{"vpn":{"network":{"con
| okta_browser_plugin       | 0oa1e5eiy5lYpLrqW5d7 | Okta Browser Plugin  | 2021-08-02 10:57:03 | <null> | 2021-08-02 10:57:03 | ACTIVE | OPENID_CONNECT | {"app":{},"notifications":{"vpn":{"network":{"con
| dev-88719661_osbornokta_1 | 0oa1e61f0xueXJoTP5d7 | osborn-okta          | 2021-08-02 13:23:03 | <null> | 2021-08-02 14:17:48 | ACTIVE | SAML_2_0       | {"app":{},"notifications":{"vpn":{"network":{"con
| okta_enduser              | 0oa1e5eiz0fXeMRKN5d7 | Okta Dashboard       | 2021-08-02 10:57:03 | <null> | 2021-08-02 10:57:03 | ACTIVE | OPENID_CONNECT | {"app":{},"notifications":{"vpn":{"network":{"con
| oidc_client               | 0oa1fku0xsXDY5TW25d7 | My Native App        | 2021-08-09 16:02:27 | <null> | 2021-08-09 16:02:27 | ACTIVE | OPENID_CONNECT | {"app":{},"notifications":{"vpn":{"network":{"con
| oidc_client               | 0oa1fkptllKHL49ED5d7 | My API Services App  | 2021-08-09 15:47:42 | <null> | 2021-08-09 15:47:42 | ACTIVE | OPENID_CONNECT | {"app":{},"notifications":{"vpn":{"network":{"con
| oidc_client               | 0oa1gdkrm16l6v28f5d7 | Test Private KeyPair | 2021-08-12 15:46:36 | <null> | 2021-08-12 15:46:36 | ACTIVE | OPENID_CONNECT | {"app":{},"notifications":{"vpn":{"network":{"con
+---------------------------+----------------------+----------------------+---------------------+--------+---------------------+--------+----------------+--------------------------------------------------
```
</details>
