### PR TITLE
Add table okta_idp_discovery_policy closes #21

### DIFF
--- a/docs/tables/okta_idp_discovery_policy.md
+++ b/docs/tables/okta_idp_discovery_policy.md
@@ -1,0 +1,70 @@
+# Table: okta_password_policy
+
+The [IdP Discovery Policy](https://developer.okta.com/docs/reference/api/policy/#idp-discovery-policy) determines where to route Users when they are attempting to sign in to your org. Users can be routed to a variety of Identity Providers (SAML2, IWA, AgentlessDSSO, X509, FACEBOOK, GOOGLE, LINKEDIN, MICROSOFT, OIDC) based on multiple conditions.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id,
+  created,
+  status,
+  priority,
+  system
+from
+  okta_idp_discovery_policy
+order by
+  priority;
+```
+
+### List system idp discovery policies
+
+```sql
+select
+  name,
+  id,
+  created,
+  status,
+  priority,
+  system
+from
+  okta_idp_discovery_policy
+where
+  system;
+```
+
+### List inactive idp discovery policies
+
+```sql
+select
+  name,
+  id,
+  created,
+  status,
+  priority,
+  system
+from
+  okta_idp_discovery_policy
+where
+  status = 'INACTIVE';
+```
+
+### Get rules details for each idp discovery policy
+
+```sql
+select
+  name,
+  id,
+  r -> 'name' as rule_name,
+  r -> 'system' as rule_system,
+  r -> 'status' as rule_status,
+  r -> 'priority' as rule_priority,
+  jsonb_pretty(r -> 'actions') as rule_actions,
+  jsonb_pretty(r -> 'conditions') as rule_conditions
+from
+  okta_idp_discovery_policy,
+  jsonb_array_elements(rules) as r;
+```

--- a/okta/plugin.go
+++ b/okta/plugin.go
@@ -19,11 +19,12 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			Schema:      ConfigSchema,
 		},
 		TableMap: map[string]*plugin.Table{
-			"okta_application":     tableOktaApplication(),
-			"okta_group":           tableOktaGroup(),
-			"okta_password_policy": tableOktaPasswordPolicy(),
-			"okta_user":            tableOktaUser(),
-			"okta_user_type":       tableOktaUserType(),
+			"okta_application":          tableOktaApplication(),
+			"okta_group":                tableOktaGroup(),
+			"okta_idp_discovery_policy": tableOktaIdpDiscoveryPolicy(),
+			"okta_password_policy":      tableOktaPasswordPolicy(),
+			"okta_user":                 tableOktaUser(),
+			"okta_user_type":            tableOktaUserType(),
 		},
 	}
 

--- a/okta/table_okta_idp_discovery_policy.go
+++ b/okta/table_okta_idp_discovery_policy.go
@@ -1,0 +1,141 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/turbot/go-kit/helpers"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableOktaIdpDiscoveryPolicy() *plugin.Table {
+	return &plugin.Table{
+		Name:        "okta_idp_discovery_policy",
+		Description: "The IdP Discovery Policy determines where to route Users when they are attempting to sign in to your org. Users can be routed to a variety of Identity Providers (SAML2, IWA, AgentlessDSSO, X509, FACEBOOK, GOOGLE, LINKEDIN, MICROSOFT, OIDC) based on multiple conditions.",
+		List: &plugin.ListConfig{
+			Hydrate: listOktaIdpDiscoveryPolicies,
+		},
+		Columns: []*plugin.Column{
+			// Top Columns
+			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the Policy."},
+			{Name: "id", Type: proto.ColumnType_STRING, Description: "Identifier of the Policy."},
+			{Name: "description", Type: proto.ColumnType_STRING, Description: "Description of the Policy."},
+			{Name: "created", Type: proto.ColumnType_TIMESTAMP, Description: "Timestamp when the Policy was created."},
+
+			// Other Columns
+			{Name: "last_updated", Type: proto.ColumnType_TIMESTAMP, Description: "Timestamp when the Policy was last modified."},
+			{Name: "priority", Type: proto.ColumnType_INT, Description: "Priority of the Policy."},
+			{Name: "status", Type: proto.ColumnType_STRING, Description: "Status of the Policy: ACTIVE or INACTIVE."},
+			{Name: "system", Type: proto.ColumnType_BOOL, Description: "This is set to true on system policies, which cannot be deleted."},
+
+			// JSON Columns
+			{Name: "conditions", Type: proto.ColumnType_JSON, Description: "Conditions for Policy."},
+			{Name: "links", Type: proto.ColumnType_JSON, Description: "Hyperlinks"},
+			{Name: "rules", Type: proto.ColumnType_JSON, Transform: transform.FromField("Embedded.rules"), Description: "Each Policy may contain one or more Rules. Rules, like Policies, contain conditions that must be satisfied for the Rule to be applied."},
+			{Name: "settings", Type: proto.ColumnType_JSON, Description: "Settings of the password policy."},
+
+			// Steampipe Columns
+			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: titleDescription},
+		},
+	}
+}
+
+func listOktaIdpDiscoveryPolicies(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	client, err := Connect(ctx, d)
+
+	input := &query.Params{}
+	if err != nil {
+		logger.Error("listOktaPolicies", "connect", err)
+		return nil, err
+	}
+
+	if d.Table.Name == "okta_idp_discovery_policy" {
+		input.Type = "IDP_DISCOVERY"
+		input.Expand = "rules"
+	}
+
+	policyType := d.KeyColumnQuals["type"].GetStringValue()
+	if input == nil && policyType == "" {
+		return nil, nil
+	} else {
+		policyType = input.Type
+	}
+
+	if !helpers.StringSliceContains(policyTypes, policyType) {
+		return nil, fmt.Errorf("%s is not a valid policy type. Valid policy types are: %s", policyType, strings.Join(policyTypes, ", "))
+	}
+
+	policies, resp, err := ListIdpDiscoveryPolicies(ctx, *client, input)
+	if err != nil {
+		logger.Error("listOktaPolicies", "list policies", err)
+		return nil, err
+	}
+
+	for _, policy := range policies {
+		d.StreamListItem(ctx, policy)
+	}
+
+	// paging
+	for resp.HasNextPage() {
+		var nextPolicySet []*okta.Policy
+		resp, err = resp.Next(ctx, &nextPolicySet)
+		if err != nil {
+			logger.Error("listOktaPolicies", "list policies paging", err)
+			return nil, err
+		}
+		for _, policy := range nextPolicySet {
+			d.StreamListItem(ctx, policy)
+		}
+	}
+
+	return nil, err
+}
+
+// generic policy missing Settings field
+type DiscoveryPolicy struct {
+	Embedded    interface{}                `json:"_embedded,omitempty"`
+	Links       interface{}                `json:"_links,omitempty"`
+	Settings    interface{}                `json:"settings,omitempty"`
+	Conditions  *okta.PolicyRuleConditions `json:"conditions,omitempty"`
+	Created     *time.Time                 `json:"created,omitempty"`
+	Description string                     `json:"description,omitempty"`
+	Id          string                     `json:"id,omitempty"`
+	LastUpdated *time.Time                 `json:"lastUpdated,omitempty"`
+	Name        string                     `json:"name,omitempty"`
+	Priority    int64                      `json:"priority,omitempty"`
+	Status      string                     `json:"status,omitempty"`
+	System      *bool                      `json:"system,omitempty"`
+	Type        string                     `json:"type,omitempty"`
+}
+
+// Gets all IDP Discovery policies with the specified type.
+func ListIdpDiscoveryPolicies(ctx context.Context, client okta.Client, qp *query.Params) ([]*DiscoveryPolicy, *okta.Response, error) {
+	url := "/api/v1/policies"
+	if qp != nil {
+		url = url + qp.String()
+	}
+
+	requestExecutor := client.GetRequestExecutor()
+	req, err := requestExecutor.WithAccept("application/json").WithContentType("application/json").NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var policies []*DiscoveryPolicy
+
+	resp, err := requestExecutor.Do(ctx, req, &policies)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return policies, resp, nil
+}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
### Basic info

```sql
select
  name,
  id,
  created,
  status,
  priority,
  system
from
  okta_idp_discovery_policy
order by
  priority;
```

```
+----------------------+----------------------+---------------------+--------+----------+--------+
| name                 | id                   | created             | status | priority | system |
+----------------------+----------------------+---------------------+--------+----------+--------+
| Idp Discovery Policy | 00p1e5eiytPPOPCft5d7 | 2021-08-02 10:57:03 | ACTIVE | 1        | true   |
+----------------------+----------------------+---------------------+--------+----------+--------+
```

### List system idp discovery policies

```sql
select
  name,
  id,
  created,
  status,
  priority,
  system
from
  okta_idp_discovery_policy
where
  system;
```

```
+----------------------+----------------------+---------------------+--------+----------+--------+
| name                 | id                   | created             | status | priority | system |
+----------------------+----------------------+---------------------+--------+----------+--------+
| Idp Discovery Policy | 00p1e5eiytPPOPCft5d7 | 2021-08-02 10:57:03 | ACTIVE | 1        | true   |
+----------------------+----------------------+---------------------+--------+----------+--------+
```

### Get rules details for each idp discovery policy

```sql
select
  name,
  id,
  r -> 'name' as rule_name,
  r -> 'system' as rule_system,
  r -> 'status' as rule_status,
  r -> 'priority' as rule_priority,
  jsonb_pretty(r -> 'actions') as rule_actions,
  jsonb_pretty(r -> 'conditions') as rule_conditions
from
  okta_idp_discovery_policy,
  jsonb_array_elements(rules) as r;
```

```
+----------------------+----------------------+----------------+-------------+-------------+---------------+--------------------------------+----------------------------------+
| name                 | id                   | rule_name      | rule_system | rule_status | rule_priority | rule_actions                   | rule_conditions                  |
+----------------------+----------------------+----------------+-------------+-------------+---------------+--------------------------------+----------------------------------+
| Idp Discovery Policy | 00p1e5eiytPPOPCft5d7 | "Default Rule" | true        | "ACTIVE"    | 1             | {                              | {                                |
|                      |                      |                |             |             |               |     "idp": {                   |     "app": {                     |
|                      |                      |                |             |             |               |         "providers": [         |         "exclude": [             |
|                      |                      |                |             |             |               |             {                  |         ],                       |
|                      |                      |                |             |             |               |                 "type": "OKTA" |         "include": [             |
|                      |                      |                |             |             |               |             }                  |         ]                        |
|                      |                      |                |             |             |               |         ]                      |     },                           |
|                      |                      |                |             |             |               |     }                          |     "network": {                 |
|                      |                      |                |             |             |               | }                              |         "connection": "ANYWHERE" |
|                      |                      |                |             |             |               |                                |     },                           |
|                      |                      |                |             |             |               |                                |     "platform": {                |
|                      |                      |                |             |             |               |                                |         "exclude": [             |
|                      |                      |                |             |             |               |                                |         ],                       |
|                      |                      |                |             |             |               |                                |         "include": [             |
|                      |                      |                |             |             |               |                                |         ]                        |
|                      |                      |                |             |             |               |                                |     },                           |
|                      |                      |                |             |             |               |                                |     "userIdentifier": {          |
|                      |                      |                |             |             |               |                                |         "patterns": [            |
|                      |                      |                |             |             |               |                                |         ]                        |
|                      |                      |                |             |             |               |                                |     }                            |
|                      |                      |                |             |             |               |                                | }                                |
+----------------------+----------------------+----------------+-------------+-------------+---------------+--------------------------------+----------------------------------+
```

</details>
