### PR TITLE
Add table okta_auth_server. Closes #19

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,6 @@ If using the Okta service application, the following scopes must be enabled for 
 - okta.apps.read
 - okta.roles.read
 - okta.policies.read
-- okta.authorizationServers.manage
 - okta.authorizationServers.read
 
 ## Get involved

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,8 @@ If using the Okta service application, the following scopes must be enabled for 
 - okta.apps.read
 - okta.roles.read
 - okta.policies.read
+- okta.authorizationServers.manage
+- okta.authorizationServers.read
 
 ## Get involved
 

--- a/docs/tables/okta_auth_server.md
+++ b/docs/tables/okta_auth_server.md
@@ -18,6 +18,24 @@ from
   okta_auth_server;
 ```
 
+### List authorization servers where manual rotation signing keys are not rotated in more than 90 days
+
+```sql
+select
+  name,
+  id,
+  audiences,
+  created,
+  last_updated, 
+  credentials -> 'signing' ->> 'lastRotated' as last_rotated,
+  status
+from
+  okta_auth_server
+where
+  credentials -> 'signing' ->> 'rotationMode' = 'MANUAL' 
+  and CAST(credentials -> 'signing' ->> 'lastRotated' as date) < current_timestamp - interval '90 days';
+```
+
 ### List inactive authorization servers
 
 ```sql
@@ -32,39 +50,4 @@ from
   okta_auth_server
 where
   status = 'INACTIVE';
-```
-
-### List authorization server links
-
-```sql
-select
-  name,
-  id,
-  status,
-  jsonb_pretty(links -> 'activate') as link_activate,
-  jsonb_pretty(links -> 'claims') as link_claims,
-  jsonb_pretty(links -> 'deactivate') as link_deactivate,
-  jsonb_pretty(links -> 'metadata') as link_metadata,
-  jsonb_pretty(links -> 'policies') as link_policies,
-  jsonb_pretty(links -> 'rotateKey') as link_rotateKey,
-  jsonb_pretty(links -> 'scopes') as link_scopes,
-  jsonb_pretty(links -> 'self') as link_self
-from
-  okta_auth_server;
-```
-
-### Get authorization server by ID
-
-```sql
-select
-  name,
-  id,
-  audiences,
-  created,
-  last_updated,
-  status
-from
-  okta_auth_server
-where
-  id = 'aus1kchdp0mdlLV7o5d7';
 ```

--- a/docs/tables/okta_auth_server.md
+++ b/docs/tables/okta_auth_server.md
@@ -1,0 +1,70 @@
+# Table: okta_auth_server
+
+An authorization server defines your security boundary, and is used to mint access and identity tokens for use with OIDC clients and OAuth 2.0 service accounts when accessing your resources via API. Within each authorization server you can define your own OAuth scopes, claims, and access policies.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id,
+  audiences,
+  created,
+  last_updated,
+  status
+from
+  okta_auth_server;
+```
+
+### List inactive authorization servers
+
+```sql
+select
+  name,
+  id,
+  audiences,
+  created,
+  last_updated,
+  status
+from
+  okta_auth_server
+where
+  status = 'INACTIVE';
+```
+
+### List authorization server links
+
+```sql
+select
+  name,
+  id,
+  status,
+  jsonb_pretty(links -> 'activate') as link_activate,
+  jsonb_pretty(links -> 'claims') as link_claims,
+  jsonb_pretty(links -> 'deactivate') as link_deactivate,
+  jsonb_pretty(links -> 'metadata') as link_metadata,
+  jsonb_pretty(links -> 'policies') as link_policies,
+  jsonb_pretty(links -> 'rotateKey') as link_rotateKey,
+  jsonb_pretty(links -> 'scopes') as link_scopes,
+  jsonb_pretty(links -> 'self') as link_self
+from
+  okta_auth_server;
+```
+
+### Get authorization server by ID
+
+```sql
+select
+  name,
+  id,
+  audiences,
+  created,
+  last_updated,
+  status
+from
+  okta_auth_server
+where
+  id = 'aus1kchdp0mdlLV7o5d7';
+```

--- a/okta/connect.go
+++ b/okta/connect.go
@@ -18,7 +18,7 @@ func Connect(ctx context.Context, d *plugin.QueryData) (*okta.Client, error) {
 	oktaConfig := GetConfig(d.Connection)
 
 	var domain, token, clientID, privateKey string
-	scopes := []string{"okta.users.read", "okta.groups.read", "okta.roles.read", "okta.apps.read", "okta.policies.read"}
+	scopes := []string{"okta.users.read", "okta.groups.read", "okta.roles.read", "okta.apps.read", "okta.policies.read", "okta.authorizationServers.manage", "okta.authorizationServers.read"}
 	if oktaConfig.Domain != nil {
 		domain = *oktaConfig.Domain
 	} else {

--- a/okta/connect.go
+++ b/okta/connect.go
@@ -18,7 +18,7 @@ func Connect(ctx context.Context, d *plugin.QueryData) (*okta.Client, error) {
 	oktaConfig := GetConfig(d.Connection)
 
 	var domain, token, clientID, privateKey string
-	scopes := []string{"okta.users.read", "okta.groups.read", "okta.roles.read", "okta.apps.read", "okta.policies.read", "okta.authorizationServers.manage", "okta.authorizationServers.read"}
+	scopes := []string{"okta.users.read", "okta.groups.read", "okta.roles.read", "okta.apps.read", "okta.policies.read", "okta.authorizationServers.read"}
 	if oktaConfig.Domain != nil {
 		domain = *oktaConfig.Domain
 	} else {

--- a/okta/plugin.go
+++ b/okta/plugin.go
@@ -20,6 +20,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		},
 		TableMap: map[string]*plugin.Table{
 			"okta_application":     tableOktaApplication(),
+			"okta_auth_server":     tableOktaAuthServer(),
 			"okta_group":           tableOktaGroup(),
 			"okta_password_policy": tableOktaPasswordPolicy(),
 			"okta_user":            tableOktaUser(),

--- a/okta/table_okta_auth_server.go
+++ b/okta/table_okta_auth_server.go
@@ -43,7 +43,6 @@ func tableOktaAuthServer() *plugin.Table {
 			// JSON Columns
 			{Name: "audiences", Type: proto.ColumnType_JSON, Description: "The audiences of the authorization server."},
 			{Name: "credentials", Type: proto.ColumnType_JSON, Description: "The authorization server credentials."},
-			{Name: "links", Type: proto.ColumnType_JSON, Description: "The authorization server link properties."},
 
 			// Steampipe Columns
 			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: titleDescription},

--- a/okta/table_okta_auth_server.go
+++ b/okta/table_okta_auth_server.go
@@ -1,0 +1,119 @@
+package okta
+
+import (
+	"context"
+	"strings"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+)
+
+//// TABLE DEFINITION
+
+func tableOktaAuthServer() *plugin.Table {
+	return &plugin.Table{
+		Name:        "okta_auth_server",
+		Description: "Represents an Okta Authorization Server.",
+		Get: &plugin.GetConfig{
+			Hydrate:           getOktaAuthServer,
+			KeyColumns:        plugin.SingleColumn("id"),
+			ShouldIgnoreError: isNotFoundError([]string{"Not found"}),
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listOktaAuthServers,
+		},
+
+		Columns: []*plugin.Column{
+			// Top columns
+			{Name: "name", Type: proto.ColumnType_STRING, Description: "The name for the authorization server."},
+			{Name: "id", Type: proto.ColumnType_STRING, Description: "Unique key for the authorization server."},
+
+			// Other columns
+			{Name: "created", Type: proto.ColumnType_TIMESTAMP, Description: "Timestamp when the authorization server was created."},
+			{Name: "description", Type: proto.ColumnType_STRING, Description: "A human-readable description of the authorization server."},
+			{Name: "issuer", Type: proto.ColumnType_STRING, Description: "The issuer URI of the authorization server."},
+			{Name: "issuer_mode", Type: proto.ColumnType_STRING, Description: "The issuer mode of the authorization server."},
+			{Name: "last_updated", Type: proto.ColumnType_TIMESTAMP, Description: "Timestamp when the authorization server was last updated."},
+			{Name: "status", Type: proto.ColumnType_STRING, Description: "The status of the authorization server."},
+
+			// JSON Columns
+			{Name: "audiences", Type: proto.ColumnType_JSON, Description: "The audiences of the authorization server."},
+			{Name: "credentials", Type: proto.ColumnType_JSON, Description: "The authorization server credentials."},
+			{Name: "links", Type: proto.ColumnType_JSON, Description: "The authorization server link properties."},
+
+			// Steampipe Columns
+			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: titleDescription},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listOktaAuthServers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	client, err := Connect(ctx, d)
+	if err != nil {
+		logger.Error("listOktaAuthServers", "connect", err)
+		return nil, err
+	}
+
+	input := query.Params{}
+	servers, resp, err := client.AuthorizationServer.ListAuthorizationServers(ctx, &input)
+	if err != nil {
+		logger.Error("listOktaAuthServers", "list auth servers", err)
+		if strings.Contains(err.Error(), "Not found") {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	for _, server := range servers {
+		d.StreamListItem(ctx, server)
+	}
+
+	// paging
+	for resp.HasNextPage() {
+		var nextAuthorizationServerSet []*okta.AuthorizationServer
+		resp, err = resp.Next(ctx, &nextAuthorizationServerSet)
+		if err != nil {
+			logger.Error("listOktaAuthServers", "list auth servers paging", err)
+			return nil, err
+		}
+		for _, server := range nextAuthorizationServerSet {
+			d.StreamListItem(ctx, server)
+		}
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTIONS
+
+func getOktaAuthServer(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Debug("getOktaAuthServer")
+
+	authServerId := d.KeyColumnQuals["id"].GetStringValue()
+
+	if authServerId == "" {
+		return nil, nil
+	}
+
+	client, err := Connect(ctx, d)
+	if err != nil {
+		logger.Error("getOktaAuthServer", "connect", err)
+		return nil, err
+	}
+
+	server, _, err := client.AuthorizationServer.GetAuthorizationServer(ctx, authServerId)
+	if err != nil {
+		logger.Error("getOktaAuthServer", "get auth server", err)
+		return nil, err
+	}
+
+	return server, nil
+}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  audiences,
  created,
  last_updated,
  status
from
  okta_auth_server;
2021-09-01T12:12:17.080+0530 [TRACE] steampipe: executor in
⠋ Loading results... 2021-09-01T12:12:19.132+0530 [TRACE] steampipe: restartInteractiveSession
2021-09-01T12:12:19.132+0530 [TRACE] steampipe: Close prompt - then 1
2021-09-01T12:12:19.132+0530 [TRACE] steampipe: executor out
+---------+----------------------+-------------------+---------------------+---------------------+----------+
| name    | id                   | audiences         | created             | last_updated        | status   |
+---------+----------------------+-------------------+---------------------+---------------------+----------+
| default | aus1kchdp0mdlLV7o5d7 | ["api://default"] | 2021-08-26 04:26:32 | 2021-08-27 05:42:17 | ACTIVE   |
| custom  | aus1kgcsraZWzYrFi5d7 | ["api://custom"]  | 2021-08-26 09:29:25 | 2021-09-01 06:41:48 | INACTIVE |
+---------+----------------------+-------------------+---------------------+---------------------+----------+
> select
  name,
  id,
  audiences,
  created,
  last_updated, 
  credentials -> 'signing' ->> 'lastRotated' as last_rotated,
  status
from
  okta_auth_server
where
  credentials -> 'signing' ->> 'rotationMode' = 'MANUAL' 
  and CAST(credentials -> 'signing' ->> 'lastRotated' as date) < current_timestamp - interval '90 days';
2021-09-01T12:12:34.451+0530 [TRACE] steampipe: executor in
2021-09-01T12:12:34.452+0530 [TRACE] steampipe: restartInteractiveSession
2021-09-01T12:12:34.452+0530 [TRACE] steampipe: Close prompt - then 1
2021-09-01T12:12:34.452+0530 [TRACE] steampipe: executor out
+------+----+-----------+---------+--------------+--------------+--------+
| name | id | audiences | created | last_updated | last_rotated | status |
+------+----+-----------+---------+--------------+--------------+--------+
+------+----+-----------+---------+--------------+--------------+--------+
> select
  name,
  id,
  audiences,
  created,
  last_updated,
  status
from
  okta_auth_server
where
  status = 'INACTIVE';
2021-09-01T12:12:44.874+0530 [TRACE] steampipe: executor in
2021-09-01T12:12:44.879+0530 [TRACE] steampipe: restartInteractiveSession
2021-09-01T12:12:44.879+0530 [TRACE] steampipe: Close prompt - then 1
2021-09-01T12:12:44.879+0530 [TRACE] steampipe: executor out
+--------+----------------------+------------------+---------------------+---------------------+----------+
| name   | id                   | audiences        | created             | last_updated        | status   |
+--------+----------------------+------------------+---------------------+---------------------+----------+
| custom | aus1kgcsraZWzYrFi5d7 | ["api://custom"] | 2021-08-26 09:29:25 | 2021-09-01 06:41:48 | INACTIVE |
+--------+----------------------+------------------+---------------------+---------------------+----------+
> 
```
</details>
