### PR TITLE
Add table okta_trusted_origin. Closes #15

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,7 @@ If using the Okta service application, the following scopes must be enabled for 
 - okta.apps.read
 - okta.roles.read
 - okta.policies.read
+- okta.trustedOrigins.read
 
 ## Get involved
 

--- a/docs/tables/okta_trusted_origin.md
+++ b/docs/tables/okta_trusted_origin.md
@@ -1,6 +1,6 @@
 # Table: okta_trusted_origin
 
-The Okta Trusted Origins API provides operations to manage Trusted Origins and sources.
+A Trusted Origin is a security-based concept that combines the URI scheme, hostname, and port number of a page. All cross-origin web requests and redirects from Okta to your organization’s websites must be explicitly allowed.
 
 When external URLs are requested during sign-in, sign-out, or recovery operations, Okta checks those URLs against the allowed list of Trusted Origins. Trusted Origins also enable browser-based applications to access Okta APIs from JavaScript (CORS). If the origins aren't specified, the related operation (redirect or Okta API access) isn't permitted.
 
@@ -36,7 +36,7 @@ from
   okta_trusted_origin;
 ```
 
-### Get authorization server by ID
+### List trusted origins last updated for more than 30 days
 
 ```sql
 select
@@ -50,5 +50,22 @@ select
 from
   okta_trusted_origin
 where
-  id = 'tos1l3v1djOJMSQkh5d7';
+  last_updated < current_timestamp - interval '30 days';
+```
+
+### List CORS scoped trusted origins
+
+```sql
+select
+  name,
+  id,
+  created,
+  last_updated,
+  origin,
+  scopes,
+  status
+from
+  okta_trusted_origin
+where
+  scopes @> '[{"type":"CORS"}]'::jsonb;
 ```

--- a/docs/tables/okta_trusted_origin.md
+++ b/docs/tables/okta_trusted_origin.md
@@ -23,20 +23,7 @@ from
   okta_trusted_origin;
 ```
 
-### List trusted origins links
-
-```sql
-select
-  name,
-  id,
-  status,
-  jsonb_pretty(links -> 'deactivate') as link_deactivate,
-  jsonb_pretty(links -> 'self') as link_self
-from
-  okta_trusted_origin;
-```
-
-### List trusted origins for more than 30 days since last updated
+### List trusted origins last updated 30 days ago
 
 ```sql
 select

--- a/docs/tables/okta_trusted_origin.md
+++ b/docs/tables/okta_trusted_origin.md
@@ -1,0 +1,54 @@
+# Table: okta_trusted_origin
+
+The Okta Trusted Origins API provides operations to manage Trusted Origins and sources.
+
+When external URLs are requested during sign-in, sign-out, or recovery operations, Okta checks those URLs against the allowed list of Trusted Origins. Trusted Origins also enable browser-based applications to access Okta APIs from JavaScript (CORS). If the origins aren't specified, the related operation (redirect or Okta API access) isn't permitted.
+
+Note: This table does not support the optional `filter` column to query results based on Okta supported [filters](https://developer.okta.com/docs/reference/api/trusted-origins/#list-trusted-origins-with-a-filter).
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id,
+  created,
+  last_updated,
+  origin,
+  scopes,
+  status
+from
+  okta_trusted_origin;
+```
+
+### List trusted origins links
+
+```sql
+select
+  name,
+  id,
+  status,
+  jsonb_pretty(links -> 'deactivate') as link_deactivate,
+  jsonb_pretty(links -> 'self') as link_self
+from
+  okta_trusted_origin;
+```
+
+### Get authorization server by ID
+
+```sql
+select
+  name,
+  id,
+  created,
+  last_updated,
+  origin,
+  scopes,
+  status
+from
+  okta_trusted_origin
+where
+  id = 'tos1l3v1djOJMSQkh5d7';
+```

--- a/docs/tables/okta_trusted_origin.md
+++ b/docs/tables/okta_trusted_origin.md
@@ -36,7 +36,7 @@ from
   okta_trusted_origin;
 ```
 
-### List trusted origins last updated for more than 30 days
+### List trusted origins for more than 30 days since last updated
 
 ```sql
 select

--- a/okta/connect.go
+++ b/okta/connect.go
@@ -18,7 +18,7 @@ func Connect(ctx context.Context, d *plugin.QueryData) (*okta.Client, error) {
 	oktaConfig := GetConfig(d.Connection)
 
 	var domain, token, clientID, privateKey string
-	scopes := []string{"okta.users.read", "okta.groups.read", "okta.roles.read", "okta.apps.read", "okta.policies.read"}
+	scopes := []string{"okta.users.read", "okta.groups.read", "okta.roles.read", "okta.apps.read", "okta.policies.read", "okta.trustedOrigins.read"}
 	if oktaConfig.Domain != nil {
 		domain = *oktaConfig.Domain
 	} else {

--- a/okta/plugin.go
+++ b/okta/plugin.go
@@ -22,6 +22,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"okta_application":     tableOktaApplication(),
 			"okta_group":           tableOktaGroup(),
 			"okta_password_policy": tableOktaPasswordPolicy(),
+			"okta_trusted_origin":  tableOktaTrustedOrigin(),
 			"okta_user":            tableOktaUser(),
 			"okta_user_type":       tableOktaUserType(),
 		},

--- a/okta/table_okta_trusted_origin.go
+++ b/okta/table_okta_trusted_origin.go
@@ -16,7 +16,7 @@ import (
 func tableOktaTrustedOrigin() *plugin.Table {
 	return &plugin.Table{
 		Name:        "okta_trusted_origin",
-		Description: "Okta Trusted Origin",
+		Description: "Trusted Origin is a security-based concept that combines the URI scheme, hostname, and port number of a page.",
 		Get: &plugin.GetConfig{
 			Hydrate:           getOktaTrustedOrigin,
 			KeyColumns:        plugin.SingleColumn("id"),
@@ -40,7 +40,6 @@ func tableOktaTrustedOrigin() *plugin.Table {
 
 			// JSON Columns
 			{Name: "scopes", Type: proto.ColumnType_JSON, Description: "The scopes for the trusted origin. Valid values are 'CORS' or 'REDIRECT'."},
-			{Name: "links", Type: proto.ColumnType_JSON, Description: "The trusted origin link properties."},
 
 			// Steampipe Columns
 			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: titleDescription},

--- a/okta/table_okta_trusted_origin.go
+++ b/okta/table_okta_trusted_origin.go
@@ -1,0 +1,113 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+)
+
+//// TABLE DEFINITION
+
+func tableOktaTrustedOrigin() *plugin.Table {
+	return &plugin.Table{
+		Name:        "okta_trusted_origin",
+		Description: "Okta Trusted Origin",
+		Get: &plugin.GetConfig{
+			Hydrate:           getOktaTrustedOrigin,
+			KeyColumns:        plugin.SingleColumn("id"),
+			ShouldIgnoreError: isNotFoundError([]string{"Not found"}),
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listOktaTrustedOrigins,
+		},
+		Columns: []*plugin.Column{
+			// Top Columns
+			{Name: "name", Type: proto.ColumnType_STRING, Description: "The name of the trusted origin."},
+			{Name: "id", Type: proto.ColumnType_STRING, Description: "A unique key for the trusted origin."},
+
+			// Other Columns
+			{Name: "created", Type: proto.ColumnType_TIMESTAMP, Description: "The timestamp when the trusted origin was created."},
+			{Name: "created_by", Type: proto.ColumnType_STRING, Description: "The ID of the user who created the trusted origin."},
+			{Name: "last_updated", Type: proto.ColumnType_TIMESTAMP, Description: "The timestamp when the trusted origin was last updated."},
+			{Name: "last_updated_by", Type: proto.ColumnType_STRING, Description: "The ID of the user who last updated the trusted origin."},
+			{Name: "origin", Type: proto.ColumnType_STRING, Description: "The origin of the trusted origin."},
+			{Name: "status", Type: proto.ColumnType_STRING, Description: "Current status of the trusted origin. Valid values are 'ACTIVE' or 'INACTIVE'."},
+
+			// JSON Columns
+			{Name: "scopes", Type: proto.ColumnType_JSON, Description: "The scopes for the trusted origin. Valid values are 'CORS' or 'REDIRECT'."},
+			{Name: "links", Type: proto.ColumnType_JSON, Description: "The trusted origin link properties."},
+
+			// Steampipe Columns
+			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: titleDescription},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listOktaTrustedOrigins(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	client, err := Connect(ctx, d)
+	if err != nil {
+		logger.Error("listOktaTrustedOrigins", "connect", err)
+		return nil, err
+	}
+
+	input := query.Params{}
+	origins, resp, err := client.TrustedOrigin.ListOrigins(ctx, &input)
+	if err != nil {
+		logger.Error("listOktaTrustedOrigins", "list trusted origins", err)
+		return nil, err
+	}
+
+	for _, origin := range origins {
+		d.StreamListItem(ctx, origin)
+	}
+
+	// paging
+	for resp.HasNextPage() {
+		var nextOriginSet []*okta.TrustedOrigin
+		resp, err = resp.Next(ctx, &nextOriginSet)
+		if err != nil {
+			logger.Error("listOktaTrustedOrigins", "list trusted origins paging", err)
+			return nil, err
+		}
+		for _, origin := range nextOriginSet {
+			d.StreamListItem(ctx, origin)
+		}
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTIONS
+
+func getOktaTrustedOrigin(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Debug("getOktaTrustedOrigin")
+
+	trustedOriginId := d.KeyColumnQuals["id"].GetStringValue()
+
+	if trustedOriginId == "" {
+		return nil, nil
+	}
+
+	client, err := Connect(ctx, d)
+	if err != nil {
+		logger.Error("getOktaTrustedOrigin", "connect", err)
+		return nil, err
+	}
+	
+	app, _, err := client.TrustedOrigin.GetOrigin(ctx, trustedOriginId)
+	if err != nil {
+		logger.Error("getOktaTrustedOrigin", "get application", err)
+		return nil, err
+	}
+
+	return app, nil
+}

--- a/okta/table_okta_trusted_origin.go
+++ b/okta/table_okta_trusted_origin.go
@@ -105,7 +105,7 @@ func getOktaTrustedOrigin(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	
 	app, _, err := client.TrustedOrigin.GetOrigin(ctx, trustedOriginId)
 	if err != nil {
-		logger.Error("getOktaTrustedOrigin", "get application", err)
+		logger.Error("getOktaTrustedOrigin", "get trusted origin", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  created,
  last_updated,
  origin,
  scopes,
  status
from
  okta_trusted_origin;
2021-09-01T21:59:18.274+0530 [TRACE] steampipe: executor in
⠼ Loading results... 2021-09-01T21:59:19.781+0530 [TRACE] steampipe: restartInteractiveSession
2021-09-01T21:59:19.782+0530 [TRACE] steampipe: Close prompt - then 1
2021-09-01T21:59:19.782+0530 [TRACE] steampipe: executor out
+----------------------+----------------------+---------------------+---------------------+------------------+---------------------------------------+--------+
| name                 | id                   | created             | last_updated        | origin           | scopes                                | status |
+----------------------+----------------------+---------------------+---------------------+------------------+---------------------------------------+--------+
| test-origin-redirect | tos1l3v1djOJMSQkh5d7 | 2021-08-27 07:44:15 | 2021-08-30 10:28:20 | http://test.com  | [{"type":"REDIRECT"}]                 | ACTIVE |
| Test CORS            | tos1m59anpeSM4if95d7 | 2021-08-30 10:28:43 | 2021-09-01 07:09:45 | http://test2.com | [{"type":"CORS"},{"type":"REDIRECT"}] | ACTIVE |
+----------------------+----------------------+---------------------+---------------------+------------------+---------------------------------------+--------+
> select
  name,
  id,
  created,
  last_updated,
  origin,
  scopes,
  status
from
  okta_trusted_origin
where
  last_updated < current_timestamp - interval '30 days';
2021-09-01T21:59:28.420+0530 [TRACE] steampipe: executor in
2021-09-01T21:59:28.434+0530 [TRACE] steampipe: restartInteractiveSession
2021-09-01T21:59:28.434+0530 [TRACE] steampipe: Close prompt - then 1
2021-09-01T21:59:28.434+0530 [TRACE] steampipe: executor out
+------+----+---------+--------------+--------+--------+--------+
| name | id | created | last_updated | origin | scopes | status |
+------+----+---------+--------------+--------+--------+--------+
+------+----+---------+--------------+--------+--------+--------+
> select
  name,
  id,
  created,
  last_updated,
  origin,
  scopes,
  status
from
  okta_trusted_origin
where
  scopes @> '[{"type":"CORS"}]'::jsonb;
2021-09-01T21:59:35.946+0530 [TRACE] steampipe: executor in
2021-09-01T21:59:35.951+0530 [TRACE] steampipe: restartInteractiveSession
2021-09-01T21:59:35.951+0530 [TRACE] steampipe: Close prompt - then 1
2021-09-01T21:59:35.951+0530 [TRACE] steampipe: executor out
+-----------+----------------------+---------------------+---------------------+------------------+---------------------------------------+--------+
| name      | id                   | created             | last_updated        | origin           | scopes                                | status |
+-----------+----------------------+---------------------+---------------------+------------------+---------------------------------------+--------+
| Test CORS | tos1m59anpeSM4if95d7 | 2021-08-30 10:28:43 | 2021-09-01 07:09:45 | http://test2.com | [{"type":"CORS"},{"type":"REDIRECT"}] | ACTIVE |
+-----------+----------------------+---------------------+---------------------+------------------+---------------------------------------+--------+
>
```
</details>
