### PR TITLE
Remove columns assigned_users and assigned_groups from table okta_application. Closes #52

### DIFF
--- a/docs/tables/okta_application.md
+++ b/docs/tables/okta_application.md
@@ -65,27 +65,3 @@ from
 where
   filter = 'group.id eq "00u1e5eizrjQKTWMA5d7"';
 ```
-
-### List assigned user details
-
-```sql
-select 
-  name,
-  id, 
-  label, 
-  jsonb_pretty(assigned_users) as assigned_users
-from
-  okta_application;
-```
-
-### List assigned group details
-
-```sql
-select 
-  name,
-  id, 
-  label, 
-  jsonb_pretty(assigned_groups) as assigned_groups
-from
-  okta_application;
-```

--- a/okta/table_okta_application.go
+++ b/okta/table_okta_application.go
@@ -51,8 +51,6 @@ func tableOktaApplication() *plugin.Table {
 			{Name: "visibility", Type: proto.ColumnType_JSON, Description: "Visibility settings for app."},
 			{Name: "credentials", Type: proto.ColumnType_JSON, Description: "Credentials for the specified signOnMode."},
 			{Name: "accessibility", Type: proto.ColumnType_JSON, Description: "Access settings for app."},
-			{Name: "assigned_users", Type: proto.ColumnType_JSON, Description: "List of users assigned to the application.", Hydrate: getUsersAssignedToApplication, Transform: transform.FromValue()},
-			{Name: "assigned_groups", Type: proto.ColumnType_JSON, Description: "List of groups assigned to the application.", Hydrate: getGroupsAssignedToApplication, Transform: transform.FromValue()},
 
 			// Steampipe Columns
 			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: titleDescription},
@@ -119,7 +117,7 @@ func listOktaApplications(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	return nil, err
 }
 
-//// HYDRATE FUNCTIONS
+//// HYDRATE FUNCTION
 
 func getOktaApplication(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
@@ -149,66 +147,4 @@ func getOktaApplication(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	}
 
 	return app, nil
-}
-
-func getUsersAssignedToApplication(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	logger := plugin.Logger(ctx)
-	logger.Debug("getUsersAssignedToApplication")
-	var appId string
-
-	if h.Item != nil {
-		appId = h.Item.(*okta.Application).Id
-	} else {
-		appId = d.KeyColumnQuals["id"].GetStringValue()
-	}
-
-	// Empty check for appId
-	if appId == "" {
-		return nil, nil
-	}
-
-	client, err := Connect(ctx, d)
-	if err != nil {
-		logger.Error("getUsersAssignedToApplication", "connect", err)
-		return nil, err
-	}
-
-	appUser, _, err := client.Application.ListApplicationUsers(ctx, appId, &query.Params{})
-	if err != nil {
-		logger.Error("getUsersAssignedToApplication", "ListApplicationUsers_error", err)
-		return nil, err
-	}
-
-	return appUser, nil
-}
-
-func getGroupsAssignedToApplication(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	logger := plugin.Logger(ctx)
-	logger.Debug("getGroupsAssignedToApplication")
-	var appId string
-
-	if h.Item != nil {
-		appId = h.Item.(*okta.Application).Id
-	} else {
-		appId = d.KeyColumnQuals["id"].GetStringValue()
-	}
-
-	// Empty check for appId
-	if appId == "" {
-		return nil, nil
-	}
-
-	client, err := Connect(ctx, d)
-	if err != nil {
-		logger.Error("getGroupsAssignedToApplication", "connect", err)
-		return nil, err
-	}
-
-	groups, _, err := client.Application.ListApplicationGroupAssignments(ctx, appId, &query.Params{})
-	if err != nil {
-		logger.Error("getGroupsAssignedToApplication", "ListApplicationGroupAssignments_error", err)
-		return nil, err
-	}
-
-	return groups, nil
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  label,
  created,
  status,
  sign_on_mode
from
  okta_application;
+---------------------+----------------------+----------------------+----------------------+--------+----------------+
| name                | id                   | label                | created              | status | sign_on_mode   |
+---------------------+----------------------+----------------------+----------------------+--------+----------------+
| saasure             | 0oa1kchdmerpZir9y5d7 | Okta Admin Console   | 2021-08-26T04:26:28Z | ACTIVE | OPENID_CONNECT |
| oidc_client         | 0oa1mf49z9iZurdzA5d7 | Service Client Name  | 2021-08-31T12:31:44Z | ACTIVE | OPENID_CONNECT |
| oidc_client         | 0oa1mf9l3dw26foa25d7 | Test Private KeyPair | 2021-08-31T12:46:30Z | ACTIVE | OPENID_CONNECT |
| okta_browser_plugin | 0oa1kcigd9Kob07k05d7 | Okta Browser Plugin  | 2021-08-26T04:26:36Z | ACTIVE | OPENID_CONNECT |
| okta_enduser        | 0oa1kchdrfcXTbEzV5d7 | Okta Dashboard       | 2021-08-26T04:26:36Z | ACTIVE | OPENID_CONNECT |
+---------------------+----------------------+----------------------+----------------------+--------+----------------+
> select
  name,
  id,
  label,
  created,
  status,
  sign_on_mode
from
  okta_application
where
  sign_on_mode = 'SAML_2_0';
+------+----+-------+---------+--------+--------------+
| name | id | label | created | status | sign_on_mode |
+------+----+-------+---------+--------+--------------+
+------+----+-------+---------+--------+--------------+
> select
  id,
  label,
  name,
  sign_on_mode,
  status
from
  okta_application as app
where
  filter = 'user.id eq "00u33m8oarePFyaTm5d7"';
+----------------------+----------------------+-------------+----------------+--------+
| id                   | label                | name        | sign_on_mode   | status |
+----------------------+----------------------+-------------+----------------+--------+
| 0oa1mf9l3dw26foa25d7 | Test Private KeyPair | oidc_client | OPENID_CONNECT | ACTIVE |
+----------------------+----------------------+-------------+----------------+--------+
> select
  id,
  label,
  name,
  sign_on_mode,
  status
from
  okta_application
where
  filter = 'group.id eq "00g33kzj6xOZvlBUQ5d7"';
+----------------------+----------------------+-------------+----------------+--------+
| id                   | label                | name        | sign_on_mode   | status |
+----------------------+----------------------+-------------+----------------+--------+
| 0oa1mf9l3dw26foa25d7 | Test Private KeyPair | oidc_client | OPENID_CONNECT | ACTIVE |
+----------------------+----------------------+-------------+----------------+--------+
```
</details>
