### PR TITLE
Add table okta_system_log

### DIFF
--- a/docs/tables/okta_system_log.md
+++ b/docs/tables/okta_system_log.md
@@ -10,7 +10,12 @@ Okta System Log captures a comprehensive set of system events related to users, 
   - log_event_time > ‘2023-03-15T00:00:00Z’ (The data will be fetched from the provided time to the current time)
   - log_event_time < ‘2023-03-15T00:00:00Z’ (The data will be fetched from one day before the provided time to the provided time)
 
-Note: This table supports an optional `filter` column to query results based on Okta supported [filters](https://developer.okta.com/docs/reference/api/system-log/#bounded-requests).
+- This table supports optional quals. Queries with optional quals are optimised to use Okta [filters](https://developer.okta.com/docs/reference/api/system-log/#bounded-requests). Optional quals are supported for the following columns:
+  - filter
+  - log_actor_id
+  - log_ip_address
+  - log_event_type
+  - log_event_time
 
 ## Examples
 
@@ -32,16 +37,14 @@ from
 
 ```sql
 select
-  log_actor_id,
   log_actor_name,
   log_ip_address,
   display_message,
-  log_event_type,
   title
 from
   okta_system_log
 where
-  log_event_time >= now() - interval '30 days';
+  log_event_time >= now() - interval '3 days';
 ```
 
 ### Show logs of a particular actor

--- a/docs/tables/okta_system_log.md
+++ b/docs/tables/okta_system_log.md
@@ -1,0 +1,106 @@
+# Table: okta_system_log
+
+Okta System Log captures a comprehensive set of system events related to users, security policies, app integrations, and other activities within an Okta organization. These logs provide an audit trail that can be used for monitoring, troubleshooting, and compliance purposes. Events in the system log range from user sign-in attempts and profile updates to admin activities and system-level actions.
+
+- By default, this table will provide data for the last 7 days. You can give the `log_event_time` value in the below ways to fetch data in a range. The examples below can guide you.
+
+  - log_event_time >= ‘2023-03-11T00:00:00Z’ and log_event_time <= ‘2023-03-15T00:00:00Z’
+  - log_event_time between ‘2023-03-11T00:00:00Z’ and ‘2023-03-15T00:00:00Z’
+  - log_event_time >= now() - interval '30 days' (The data will be fetched from the last 30 days)
+  - log_event_time > ‘2023-03-15T00:00:00Z’ (The data will be fetched from the provided time to the current time)
+  - log_event_time < ‘2023-03-15T00:00:00Z’ (The data will be fetched from one day before the provided time to the provided time)
+
+Note: This table supports an optional `filter` column to query results based on Okta supported [filters](https://developer.okta.com/docs/reference/api/system-log/#bounded-requests).
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  log_actor_id,
+  log_actor_name,
+  log_ip_address,
+  display_message,
+  log_event_type,
+  title
+from
+  okta_system_log;
+```
+
+### List logs which occur in last 30 days
+
+```sql
+select
+  log_actor_id,
+  log_actor_name,
+  log_ip_address,
+  display_message,
+  log_event_type,
+  title
+from
+  okta_system_log
+where
+  log_event_time >= now() - interval '30 days';
+```
+
+### Show logs of a particular actor
+
+```sql
+select
+  log_actor_id,
+  log_actor_name,
+  log_ip_address,
+  display_message,
+  log_event_type,
+  title
+from
+  okta_system_log
+where
+  log_actor_name = 'sourav';
+```
+
+### Show error logs
+
+```sql
+select
+  log_actor_id,
+  log_actor_name,
+  log_ip_address,
+  display_message,
+  log_event_type,
+  severity
+from
+  okta_system_log
+where
+  severity = 'ERROR';
+```
+
+### List target details of the logs
+
+```sql
+select
+  title,
+  severity,
+  t ->> 'alternateId' as target_alternate_id,
+  t ->> 'displayName' as target_name,
+  t ->> 'id' as target_id,
+  t ->> 'type' as target_type,
+  t -> 'detailEntry' as detail_entry
+from
+  okta_system_log,
+  jsonb_array_elements(target) as t;
+```
+
+### List transaction details of the logs
+
+```sql
+select
+  title,
+  severity,
+  transaction ->> 'id' as transaction_id,
+  transaction ->> 'type' as transaction_type,
+  transaction -> 'detail' as transaction_detail
+from
+  okta_system_log;
+```

--- a/docs/tables/okta_system_log.md
+++ b/docs/tables/okta_system_log.md
@@ -107,3 +107,19 @@ select
 from
   okta_system_log;
 ```
+
+### List events that match the filter pattern term **eventType**
+
+```sql
+select
+  log_actor_id,
+  log_actor_name,
+  log_ip_address,
+  display_message,
+  log_event_type,
+  severity
+from
+  okta_system_log
+where
+  filter = 'eventType eq "user.session.start"';
+```

--- a/okta/plugin.go
+++ b/okta/plugin.go
@@ -30,6 +30,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"okta_network_zone":         tableOktaNetworkZone(),
 			"okta_password_policy":      tableOktaPasswordPolicy(),
 			"okta_signon_policy":        tableOktaSignonPolicy(),
+			"okta_system_log":           tableOktaSystemLog(),
 			"okta_trusted_origin":       tableOktaTrustedOrigin(),
 			"okta_user":                 tableOktaUser(),
 			"okta_user_type":            tableOktaUserType(),

--- a/okta/table_okta_system_log.go
+++ b/okta/table_okta_system_log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
@@ -195,10 +196,11 @@ func listOktaSystemLogs(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	if d.Quals["log_event_time"] != nil {
 		for _, q := range d.Quals["log_event_time"].Quals {
 			timestamp := q.Value.GetTimestampValue().AsTime().Format(filterTimeFormat)
+			timestampAdd := q.Value.GetTimestampValue().AsTime().Add(time.Second).Format(filterTimeFormat)
 			switch q.Operator {
 			case "=":
 				input.Since = timestamp
-				input.Until = timestamp
+				input.Until = timestampAdd
 			case ">=", ">":
 				input.Since = timestamp
 			case "<", "<=":

--- a/okta/table_okta_system_log.go
+++ b/okta/table_okta_system_log.go
@@ -1,0 +1,261 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/turbot/go-kit/helpers"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+//// TABLE DEFINITION
+
+func tableOktaSystemLog() *plugin.Table {
+	return &plugin.Table{
+		Name:        "okta_system_log",
+		Description: "Get all the system log events.",
+		List: &plugin.ListConfig{
+			Hydrate: listOktaSystemLogs,
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "log_actor_id", Require: plugin.Optional},
+				{Name: "log_ip_address", Require: plugin.Optional},
+				{Name: "log_event_type", Require: plugin.Optional},
+				{Name: "filter", Require: plugin.Optional},
+				{Name: "log_event_time", Operators: []string{">", ">=", "=", "<", "<="}, Require: plugin.Optional},
+			},
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "log_actor_id",
+				Type:        proto.ColumnType_STRING,
+				Description: "The Id of the log actor.",
+				Transform:   transform.FromField("Actor.Id"),
+			},
+			{
+				Name:        "log_actor_name",
+				Type:        proto.ColumnType_STRING,
+				Description: "The name of the log actor.",
+				Transform:   transform.FromField("Actor.DisplayName"),
+			},
+			{
+				Name:        "actor",
+				Type:        proto.ColumnType_JSON,
+				Description: "Represents who or what performed the action.",
+			},
+			{
+				Name:        "authentication_context",
+				Type:        proto.ColumnType_JSON,
+				Description: "Provides context about the authentication.",
+			},
+			{
+				Name:        "log_ip_address",
+				Type:        proto.ColumnType_IPADDR,
+				Description: "The log IP address.",
+				Transform:   transform.FromField("Client.IpAddress"),
+			},
+			{
+				Name:        "client",
+				Type:        proto.ColumnType_JSON,
+				Description: "Provides details about the client or user-agent making the request.",
+			},
+			{
+				Name:        "debug_context",
+				Type:        proto.ColumnType_JSON,
+				Description: "Information useful for debugging.",
+			},
+			{
+				Name:        "display_message",
+				Type:        proto.ColumnType_STRING,
+				Description: "A human-readable message for the event.",
+			},
+			{
+				Name:        "log_event_type",
+				Type:        proto.ColumnType_STRING,
+				Description: "The type or nature of the event.",
+				Transform:   transform.FromField("EventType"),
+			},
+			{
+				Name:        "legacy_event_type",
+				Type:        proto.ColumnType_STRING,
+				Description: "The type of the event in older versions (if any).",
+			},
+			{
+				Name:        "outcome",
+				Type:        proto.ColumnType_JSON,
+				Description: "Represents the result of the action (success, failure, etc.)",
+			},
+			{
+				Name:        "log_event_time",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "Timestamp indicating when the log event was generated or published.",
+				Transform:   transform.FromField("Published"),
+			},
+			{
+				Name:        "request",
+				Type:        proto.ColumnType_JSON,
+				Description: "Details about the incoming request.",
+			},
+			{
+				Name:        "security_context",
+				Type:        proto.ColumnType_JSON,
+				Description: "Context related to the security aspects of the event.",
+			},
+			{
+				Name:        "severity",
+				Type:        proto.ColumnType_STRING,
+				Description: "The seriousness or urgency of the event (like 'info', 'warning', 'error', etc.)",
+			},
+			{
+				Name:        "target",
+				Type:        proto.ColumnType_JSON,
+				Description: "Represents the target or the object being acted upon.",
+			},
+			{
+				Name:        "transaction",
+				Type:        proto.ColumnType_JSON,
+				Description: "Details about the transaction.",
+			},
+			{
+				Name:        "log_event_id",
+				Type:        proto.ColumnType_STRING,
+				Description: "A unique identifier for the log event.",
+				Transform:   transform.FromField("Uuid"),
+			},
+			{
+				Name:        "version",
+				Type:        proto.ColumnType_STRING,
+				Description: "The version of the event.",
+			},
+			{
+				Name:        "filter",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("filter"),
+				Description: "Filter string to [filter](https://developer.okta.com/docs/reference/api/system-log/#bounded-requests) events. Input filter query should not be encoded.",
+			},
+
+			// Steampipe Columns
+			{
+				Name:        "title",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Uuid"),
+				Description: titleDescription,
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listOktaSystemLogs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	client, err := Connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("listOktaSystemLogs", "connect_error", err)
+		return nil, err
+	}
+
+	// Default maximum limit set as per documentation
+	// https://developer.okta.com/docs/reference/api/system-log/#request-parameters
+	input := query.Params{
+		Limit: 3,
+	}
+
+	// If the requested number of items is less than the paging max limit
+	// set the limit to that instead
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < input.Limit {
+			input.Limit = *limit
+		}
+	}
+
+	equalQuals := d.EqualsQuals
+	var queryFilter string
+	filter := buildSystemLogQueryFilter(equalQuals, []string{"log_actor_id", "log_event_type", "log_ip_address"})
+
+	// set the start and end time based on the provided log_event_time
+	// https://developer.okta.com/docs/reference/api/system-log/#request-parameters
+	if d.Quals["log_event_time"] != nil {
+		for _, q := range d.Quals["log_event_time"].Quals {
+			timestamp := q.Value.GetTimestampValue().AsTime().Format(filterTimeFormat)
+			switch q.Operator {
+			case "=":
+				input.Since = timestamp
+				input.Until = timestamp
+			case ">=", ">":
+				input.Since = timestamp
+			case "<", "<=":
+				input.Until = timestamp
+			}
+		}
+	}
+
+	if d.EqualsQualString("filter") != "" {
+		queryFilter = d.EqualsQualString("filter")
+	}
+
+	if queryFilter != "" {
+		input.Filter = queryFilter
+	} else if len(filter) > 0 {
+		input.Filter = strings.Join(filter, " and ")
+	}
+	events, resp, err := client.LogEvent.GetLogs(ctx, &input)
+	if err != nil {
+		plugin.Logger(ctx).Error("listOktaSystemLogs", "GetLogs", err)
+		return nil, err
+	}
+	for _, event := range events {
+		d.StreamListItem(ctx, event)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+
+	// paging
+	for {
+		var nextLogSet []*okta.LogEvent
+		resp, err = resp.Next(ctx, &nextLogSet)
+		if err != nil {
+			plugin.Logger(ctx).Error("listOktaSystemLogs", "list_logs_paging_error", err)
+			return nil, err
+		}
+		if len(nextLogSet) == 0 {
+			break
+		}
+		for _, event := range nextLogSet {
+			d.StreamListItem(ctx, event)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func buildSystemLogQueryFilter(equalQuals plugin.KeyColumnEqualsQualMap, filterKeys []string) []string {
+	filters := []string{}
+
+	for k, v := range equalQuals {
+		if v != nil && helpers.StringSliceContains(filterKeys, k) {
+			if k == "log_actor_id" {
+				filters = append(filters, fmt.Sprintf("actor.id eq \"%s\"", v.GetStringValue()))
+			} else if k == "log_ip_address" {
+				filters = append(filters, fmt.Sprintf("client.ipAddress eq \"%s\"", v.GetInetValue().GetAddr()))
+			} else {
+				filters = append(filters, fmt.Sprintf("eventType eq \"%s\"", v.GetStringValue()))
+			}
+		}
+	}
+
+	return filters
+}

--- a/okta/table_okta_system_log.go
+++ b/okta/table_okta_system_log.go
@@ -44,6 +44,18 @@ func tableOktaSystemLog() *plugin.Table {
 				Transform:   transform.FromField("Actor.DisplayName"),
 			},
 			{
+				Name:        "log_actor_email",
+				Type:        proto.ColumnType_STRING,
+				Description: "The email of the log actor.",
+				Transform:   transform.From(actorTurbotData),
+			},
+			{
+				Name:        "log_actor_username",
+				Type:        proto.ColumnType_STRING,
+				Description: "The username of the log actor.",
+				Transform:   transform.From(actorTurbotData),
+			},
+			{
 				Name:        "actor",
 				Type:        proto.ColumnType_JSON,
 				Description: "Represents who or what performed the action.",
@@ -258,4 +270,16 @@ func buildSystemLogQueryFilter(equalQuals plugin.KeyColumnEqualsQualMap, filterK
 	}
 
 	return filters
+}
+
+//// TRANSFORM FUNCTIONS
+
+func actorTurbotData(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	event := d.HydrateItem.(*okta.LogEvent)
+
+	if strings.Contains(event.Actor.AlternateId, "@") {
+		return event.Actor.AlternateId, nil
+	}
+
+	return nil, nil
 }

--- a/okta/table_okta_system_log.go
+++ b/okta/table_okta_system_log.go
@@ -162,7 +162,7 @@ func listOktaSystemLogs(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	// Default maximum limit set as per documentation
 	// https://developer.okta.com/docs/reference/api/system-log/#request-parameters
 	input := query.Params{
-		Limit: 3,
+		Limit: 1000,
 	}
 
 	// If the requested number of items is less than the paging max limit


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
select
  log_actor_name,
  log_ip_address,
  display_message,
  title
from
  okta_system_log
where
  log_event_time >= now() - interval '3 days';
+----------------------+----------------+-------------------------------------+--------------------------------------+
| log_actor_name       | log_ip_address | display_message                     | title                                |
+----------------------+----------------+-------------------------------------+--------------------------------------+
| Okta System          | <null>         | Administrator consent granted.      | cc6d07a4-3f8d-11ee-950b-09c46ac7f661 |
| sourav chakraborty   | 49.37.54.149   | Evaluation of sign-on policy        | dddfe77b-40e9-11ee-bbae-5305cf2fd7dd |
| supportuser@okta.com | <null>         | Update application                  | cc717477-3f8d-11ee-950b-09c46ac7f661 |
| Okta System          | 49.37.54.149   | Authenticate user with social login | ddcef786-40e9-11ee-bbae-5305cf2fd7dd |
| Okta Admin Console   | 49.37.54.149   | OIDC authorization code request     | e0655964-40e9-11ee-910f-75851e573412 |
| sourav chakraborty   | 49.37.54.149   | User login to Okta                  | dde083bf-40e9-11ee-bbae-5305cf2fd7dd |
| sourav chakraborty   | 49.37.54.149   | Evaluation of sign-on policy        | e057288e-40e9-11ee-910f-75851e573412 |
| Okta Admin Console   | 54.71.214.179  | OIDC id token is granted            | e0e9a4a3-40e9-11ee-9b34-5514329e0bbd |
| sourav chakraborty   | 54.71.214.179  | User single sign on to app          | e0e9a4a4-40e9-11ee-9b34-5514329e0bbd |
| sourav chakraborty   | 49.37.54.149   | User accessing Okta admin app       | e0f20917-40e9-11ee-9b34-5514329e0bbd |
| Okta Admin Console   | 54.71.214.179  | OIDC access token is granted        | e0e9cbb5-40e9-11ee-9b34-5514329e0bbd |
+----------------------+----------------+-------------------------------------+--------------------------------------+

select
  title,
  severity,
  transaction ->> 'id' as transaction_id,
  transaction ->> 'type' as transaction_type,
  transaction -> 'detail' as transaction_detail
from
  okta_system_log;
+--------------------------------------+----------+-----------------------------+------------------+--------------------+
| title                                | severity | transaction_id              | transaction_type | transaction_detail |
+--------------------------------------+----------+-----------------------------+------------------+--------------------+
| 19417d57-3d0f-11ee-a8d0-a5f67ff631df | INFO     | moiav0n56lZqhlG8v5d7        | JOB              | {}                 |
| cc6d07a4-3f8d-11ee-950b-09c46ac7f661 | INFO     | moiawg0ybft7w1GHi5d7        | JOB              | {}                 |
| 1946fb98-3d0f-11ee-a8d0-a5f67ff631df | INFO     | moiav0n56lZqhlG8v5d7        | JOB              | {}                 |
| cc717477-3f8d-11ee-950b-09c46ac7f661 | INFO     | moiawg0ybft7w1GHi5d7        | JOB              | {}                 |
| dddfe77b-40e9-11ee-bbae-5305cf2fd7dd | INFO     | ZOSuEHMpuFVepPJsw1QbLQAADw8 | WEB              | {}                 |
| ddcef786-40e9-11ee-bbae-5305cf2fd7dd | INFO     | ZOSuEHMpuFVepPJsw1QbLQAADw8 | WEB              | {}                 |
| e0655964-40e9-11ee-910f-75851e573412 | INFO     | ZOSuFL4JuFepP2vd0CFRYgAABa0 | WEB              | {}                 |
| dde083bf-40e9-11ee-bbae-5305cf2fd7dd | INFO     | ZOSuEHMpuFVepPJsw1QbLQAADw8 | WEB              | {}                 |
| e057288e-40e9-11ee-910f-75851e573412 | INFO     | ZOSuFL4JuFepP2vd0CFRYgAABa0 | WEB              | {}                 |
| e0e9a4a3-40e9-11ee-9b34-5514329e0bbd | INFO     | ZOSuFdYPgHHnoaaiTD1XWwAADLw | WEB              | {}                 |
| e0e9a4a4-40e9-11ee-9b34-5514329e0bbd | INFO     | ZOSuFdYPgHHnoaaiTD1XWwAADLw | WEB              | {}                 |
| e0f20917-40e9-11ee-9b34-5514329e0bbd | INFO     | ZOSuFUBJ_Gk4T3H98K9H_wAABCA | WEB              | {}                 |
| e0e9cbb5-40e9-11ee-9b34-5514329e0bbd | INFO     | ZOSuFdYPgHHnoaaiTD1XWwAADLw | WEB              | {}                 |
+--------------------------------------+----------+-----------------------------+------------------+--------------------+
```
</details>
