### PR TITLE
The common column `domain` value should be populated if domain has been set as environment variable OKTA_CLIENT_ORGURL

### DIFF
--- a/config/okta.spc
+++ b/config/okta.spc
@@ -2,18 +2,20 @@ connection "okta" {
   plugin = "okta"
 
   # Get your API token from Okta https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/
+  # Can also be set with the OKTA_CLIENT_ORGURL environment variable.
   # domain = "https://<your_okta_domain>.okta.com"
 
   # Okta API token. Can also be set with the OKTA_CLIENT_TOKEN environment variable.
   # token  = "02d0YZgNSJwlNew6lZG-6qGThisisatest-token"
 
   # Or use an Okta application and the client credentials flow for authenticating: https://developer.okta.com/docs/guides/implement-oauth-for-okta-serviceapp/overview/
+  # Can also be set with the OKTA_CLIENT_ORGURL environment variable.
   # domain      = "https://<your_okta_domain>.okta.com"
 
   # Okta App client id, used with PrivateKey OAuth auth mode. Can also be set with the OKTA_CLIENT_CLIENTID environment variable.
   # client_id   = "0oa10zpa2bo6tAm9Test"
 
-  # Private key value. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable.
+  # Private key value. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable.
   # private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAK..."
 
   # The maximum number of attempts (including the initial call) Steampipe will

--- a/config/okta.spc
+++ b/config/okta.spc
@@ -15,7 +15,7 @@ connection "okta" {
   # Okta App client id, used with PrivateKey OAuth auth mode. Can also be set with the OKTA_CLIENT_CLIENTID environment variable.
   # client_id   = "0oa10zpa2bo6tAm9Test"
 
-  # Private key value. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable.
+  # Private key value. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable.
   # private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAK..."
 
   # The maximum number of attempts (including the initial call) Steampipe will

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ connection "okta" {
   # Okta App client id, used with PrivateKey OAuth auth mode. Can also be set with the OKTA_CLIENT_CLIENTID environment variable.
   # client_id   = "0oa10zpa2bo6tAm9Test"
 
-  # Private key value. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable.
+  # Private key value. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable.
   # private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAK..."
 
   # The maximum number of attempts (including the initial call) Steampipe will

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,12 +70,20 @@ connection "okta" {
   plugin = "okta"
 
   # Get your API token from Okta https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/
+  # Can also be set with the OKTA_CLIENT_ORGURL environment variable.
   # domain = "https://<your_okta_domain>.okta.com"
+
+  # Okta API token. Can also be set with the OKTA_CLIENT_TOKEN environment variable.
   # token  = "02d0YZgNSJwlNew6lZG-6qGThisisatest-token"
 
   # Or use an Okta application and the client credentials flow for authenticating: https://developer.okta.com/docs/guides/implement-oauth-for-okta-serviceapp/overview/
+  # Can also be set with the OKTA_CLIENT_ORGURL environment variable.
   # domain      = "https://<your_okta_domain>.okta.com"
+
+  # Okta App client id, used with PrivateKey OAuth auth mode. Can also be set with the OKTA_CLIENT_CLIENTID environment variable.
   # client_id   = "0oa10zpa2bo6tAm9Test"
+
+  # Private key value. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable. Can also be set with the OKTA_CLIENT_PRIVATEKEY environment variable.
   # private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAK..."
 
   # The maximum number of attempts (including the initial call) Steampipe will

--- a/okta/common_column.go
+++ b/okta/common_column.go
@@ -2,6 +2,7 @@ package okta
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -38,10 +39,16 @@ func getOktaDomainNameCacheKey(ctx context.Context, d *plugin.QueryData, h *plug
 }
 
 func getOktaDomainNameUncached(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-
 	cfg := GetConfig(d.Connection)
 
-	domainName := strings.Split(*cfg.Domain, "https://")[1]
+	domain := cfg.Domain
+
+	if domain == nil {
+		d := os.Getenv("OKTA_CLIENT_ORGURL")
+		domain = &d
+	}
+
+	domainName := strings.Split(*domain, "https://")[1]
 
 	return domainName, nil
 }


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select domain, factor_type from okta_factor
+-----------------------+---------------------+
| domain                | factor_type         |
+-----------------------+---------------------+
| dev-50078045.okta.com | token:software:totp |
| dev-50078045.okta.com | sms                 |
| dev-50078045.okta.com | push                |
+-----------------------+---------------------+

```
</details>
