### PR TITLE
Fix nil pointer dereference error for okta_factor table

### DIFF
--- a/okta/table_okta_factor.go
+++ b/okta/table_okta_factor.go
@@ -59,7 +59,12 @@ func tableOktaFactor() *plugin.Table {
 type UserFactorInfo struct {
 	UserId   string
 	UserName string
-	Factor   interface{}
+	Factor   OktaFactor
+}
+
+type OktaFactor struct {
+	oktav4.UserFactor
+	Profile interface{}
 }
 
 //// LIST FUNCTION
@@ -111,10 +116,11 @@ func listOktaFactors(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 
 	for _, factor := range factors {
 		if factor.GetActualInstance() != nil {
+			factorDetails := getFactorDetails(factor.GetActualInstance())
 			d.StreamListItem(ctx, UserFactorInfo{
 				UserId:   userId,
 				UserName: userName,
-				Factor:   factor.GetActualInstance(),
+				Factor:   factorDetails,
 			})
 
 			// Context can be cancelled due to manual cancellation or the limit has been hit
@@ -135,10 +141,11 @@ func listOktaFactors(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 
 		for _, factor := range nextFactorSet {
 			if factor.GetActualInstance() != nil {
+				f := getFactorDetails(factor.GetActualInstance())
 				d.StreamListItem(ctx, UserFactorInfo{
 					UserId:   userId,
 					UserName: userName,
-					Factor:   factor.GetActualInstance(),
+					Factor:   f,
 				})
 
 				// Context can be cancelled due to manual cancellation or the limit has been hit
@@ -192,6 +199,77 @@ func getOktaFactor(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	if result.GetActualInstance() == nil {
 		return nil, nil
 	}
+	f := getFactorDetails(result.GetActualInstance())
 
-	return &UserFactorInfo{UserId: userId, UserName: *userName, Factor: result.GetActualInstance()}, nil
+	return &UserFactorInfo{UserId: userId, UserName: *userName, Factor: f}, nil
+}
+
+//// UTILITY FUNCTION
+
+func getFactorDetails(i interface{}) OktaFactor {
+	f := OktaFactor{}
+
+	switch item := i.(type) {
+	case *oktav4.UserFactorCall:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorCustomHOTP:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorEmail:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorHardware:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorPush:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorSMS:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorSecurityQuestion:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorTOTP:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorToken:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorU2F:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorWeb:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	case *oktav4.UserFactorWebAuthn:
+		f = OktaFactor{
+			item.UserFactor,
+			item.Profile,
+		}
+	}
+	return f
 }

--- a/okta/table_okta_factor.go
+++ b/okta/table_okta_factor.go
@@ -110,15 +110,17 @@ func listOktaFactors(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	}
 
 	for _, factor := range factors {
-		d.StreamListItem(ctx, UserFactorInfo{
-			UserId:   userId,
-			UserName: userName,
-			Factor:   factor.GetActualInstance(),
-		})
+		if factor.GetActualInstance() != nil {
+			d.StreamListItem(ctx, UserFactorInfo{
+				UserId:   userId,
+				UserName: userName,
+				Factor:   factor.GetActualInstance(),
+			})
 
-		// Context can be cancelled due to manual cancellation or the limit has been hit
-		if d.RowsRemaining(ctx) == 0 {
-			return nil, nil
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
 		}
 	}
 
@@ -132,15 +134,17 @@ func listOktaFactors(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 		}
 
 		for _, factor := range nextFactorSet {
-			d.StreamListItem(ctx, UserFactorInfo{
-				UserId:   userId,
-				UserName: userName,
-				Factor:   factor.GetActualInstance(),
-			})
+			if factor.GetActualInstance() != nil {
+				d.StreamListItem(ctx, UserFactorInfo{
+					UserId:   userId,
+					UserName: userName,
+					Factor:   factor.GetActualInstance(),
+				})
 
-			// Context can be cancelled due to manual cancellation or the limit has been hit
-			if d.RowsRemaining(ctx) == 0 {
-				return nil, nil
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.RowsRemaining(ctx) == 0 {
+					return nil, nil
+				}
 			}
 		}
 	}
@@ -183,6 +187,10 @@ func getOktaFactor(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	if err != nil {
 		logger.Error("okta_factor.getOktaFactor", "api_error", err)
 		return nil, err
+	}
+
+	if result.GetActualInstance() == nil {
+		return nil, nil
 	}
 
 	return &UserFactorInfo{UserId: userId, UserName: *userName, Factor: result.GetActualInstance()}, nil


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
With empty row:

> select * from okta_admin.okta_factor
+--------+----+---------+-----------+-------------+---------+--------------+----------+--------+---------+----------+--------+-------+--------------------+--------+------+
| domain | id | user_id | user_name | factor_type | created | last_updated | provider | status | profile | embedded | verify | title | sp_connection_name | sp_ctx | _ctx |
+--------+----+---------+-----------+-------------+---------+--------------+----------+--------+---------+----------+--------+-------+--------------------+--------+------+
+--------+----+---------+-----------+-------------+---------+--------------+----------+--------+---------+----------+--------+-------+--------------------+--------+------+

Okta classic Account:

> select * from okta_factor
+-----------------------+----------------------+----------------------+-------------------+---------------------+---------------------------+---------------------------+----------+--------------------+---------------------------------->
| domain                | id                   | user_id              | user_name         | factor_type         | created                   | last_updated              | provider | status             | profile                          >
+-----------------------+----------------------+----------------------+-------------------+---------------------+---------------------------+---------------------------+----------+--------------------+---------------------------------->
| dev-12345678.okta.com | ost1m64qvuJk6dICv5d7 | 00u1kcfw5yDiVG80P5d7 | myname@workkt.com | token:software:totp | 2021-08-30T18:23:16+05:30 | 2024-04-02T23:07:58+05:30 | OKTA     | ACTIVE             | {"credentialId":"partha@turbot.co>
| dev-12345678.okta.com | mbl1m6472anhxTgOE5d7 | 00u1kcfw5yDiVG80P5d7 | myname@workkt.com | sms                 | 2021-08-30T18:24:44+05:30 | 2021-08-30T18:24:44+05:30 | OKTA     | PENDING_ACTIVATION | {"phoneNumber":"+919776252898"}  >
| dev-12345678.okta.com | opfg6o5fqcXWpMfKY5d7 | 00u1kcfw5yDiVG80P5d7 | myname@workkt.com | push                | 2024-04-02T23:07:34+05:30 | 2024-04-02T23:07:58+05:30 | OKTA     | ACTIVE             | {"credentialId":"partha@turbot.co>
+-----------------------+----------------------+----------------------+-------------------+---------------------+---------------------------+---------------------------+----------+--------------------+---------------------------------->

Okta OIE Account:

> select * from okta_admin.okta_factor
+------------------------+----------------------+----------------------+-------------------+---------------------+---------------------------+---------------------------+----------+--------+--------------------------------------------->
| domain                 | id                   | user_id              | user_name         | factor_type         | created                   | last_updated              | provider | status | profile                                     >
+------------------------+----------------------+----------------------+-------------------+---------------------+---------------------------+---------------------------+----------+--------+--------------------------------------------->
| trial-1234567.okta.com | osthk5nek8Oywuf1R697 | 00uhizi5hzEfXoGB8697 | myname@workkt.com | token:software:totp | 2024-08-07T10:21:40+05:30 | 2024-08-07T10:21:40+05:30 | OKTA     | ACTIVE | {"credentialId":"myname@workkt.com"}        >
| trial-1234567.okta.com | opfhk5nek7COL47M5697 | 00uhizi5hzEfXoGB8697 | myname@workkt.com | push                | 2024-08-07T10:21:40+05:30 | 2024-08-07T10:21:40+05:30 | OKTA     | ACTIVE | {"credentialId":"myname@workkt.com","deviceT>
|                        |                      |                      |                   |                     |                           |                           |          |        | n":"10:2021-08-01"}                         >
+------------------------+----------------------+----------------------+-------------------+---------------------+---------------------------+---------------------------+----------+--------+--------------------------------------------->
```
</details>
