### PR TITLE
Fixed the column `rules` to populate all the properties correctly for the tables okta_signon_policy, okta_password_policy, okta_idp_discovery_policy and okta_authentication_policy Closes #144

### DIFF
--- a/okta/utils.go
+++ b/okta/utils.go
@@ -2,6 +2,7 @@ package okta
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/ettle/strcase"
 	"github.com/turbot/go-kit/helpers"
@@ -47,4 +48,42 @@ func buildQueryFilter(equalQuals plugin.KeyColumnEqualsQualMap, filterKeys []str
 	}
 
 	return filters
+}
+
+// StructToMap converts the fields of a struct from interface{} to map[string]interface{}
+func structToMap(input interface{}) (map[string]interface{}, error) {
+	// Create the result map
+	if input == nil {
+		return nil, nil
+	}
+	result := make(map[string]interface{})
+
+	// Get the value and type of the input
+	value := reflect.ValueOf(input)
+	typ := reflect.TypeOf(input)
+
+	// Ensure the input is a struct or a pointer to a struct
+	if value.Kind() == reflect.Ptr {
+		value = value.Elem()
+		typ = typ.Elem()
+	}
+
+	if value.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("input must be a struct or a pointer to a struct")
+	}
+
+	// Iterate over struct fields
+	for i := 0; i < value.NumField(); i++ {
+		// Get field name and value
+		field := value.Field(i)
+		fieldType := typ.Field(i)
+		fieldName := fieldType.Name
+
+		// Only exportable fields (starting with an uppercase letter) can be accessed
+		if field.CanInterface() {
+			result[fieldName] = field.Interface()
+		}
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

## Identity Engine:  

```
> select 
  name,
  r -> 'PolicyRule' ->> 'type'  as policy_name,
  r -> 'PolicyRule' ->> 'name'  as policy_type,
  r -> 'Actions' as policy_actions
from 
  okta_admin.okta_password_policy,
  jsonb_array_elements(rules) as r

+----------------+-------------+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name           | policy_name | policy_type  | policy_actions                                                                                                                                                                                               |
+----------------+-------------+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Default Policy | PASSWORD    | test         | {"passwordChange":{"access":"ALLOW"},"selfServicePasswordReset":{"access":"ALLOW","requirement":{"primary":{"methods":["email","push"]},"stepUp":{"required":true}}},"selfServiceUnlock":{"access":"ALLOW"}} |
| Default Policy | PASSWORD    | Default Rule | {"passwordChange":{"access":"ALLOW"},"selfServicePasswordReset":{"access":"ALLOW","requirement":{"primary":{"methods":["email"]},"stepUp":{"required":false}}},"selfServiceUnlock":{"access":"DENY"}}        |
+----------------+-------------+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

Time: 1.8s. Rows returned: 2. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) okta_password_policy.okta_admin: Time: 1.7s. Fetched: 1. Hydrates: 1.

> select 
  name,
  r -> 'PolicyRule' ->> 'type'  as policy_name,
  r -> 'PolicyRule' ->> 'name'  as policy_type,
  r -> 'Actions' as policy_actions
from 
  okta_admin.okta_signon_policy,
  jsonb_array_elements(rules) as r
+----------------+-------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name           | policy_name | policy_type  | policy_actions                                                                                                                                                                                                                  |
+----------------+-------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Default Policy | SIGN_ON     | Default Rule | {"signon":{"access":"ALLOW","primaryFactor":"PASSWORD_IDP_ANY_FACTOR","rememberDeviceByDefault":false,"requireFactor":false,"session":{"maxSessionIdleMinutes":120,"maxSessionLifetimeMinutes":0,"usePersistentCookie":false}}} |
+----------------+-------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

Time: 0.8s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) okta_signon_policy.okta_admin: Time: 0.7s. Fetched: 1. Hydrates: 1.

> select 
  name,
  r -> 'PolicyRule' ->> 'type'  as policy_name,
  r -> 'PolicyRule' ->> 'name'  as policy_type,
  r -> 'Actions' as policy_actions
from 
  okta_admin.okta_idp_discovery_policy,
  jsonb_array_elements(rules) as r
+----------------------+---------------+--------------+-----------------------------------------------------------------------+
| name                 | policy_name   | policy_type  | policy_actions                                                        |
+----------------------+---------------+--------------+-----------------------------------------------------------------------+
| Idp Discovery Policy | IDP_DISCOVERY | Default Rule | {"idp":{"idpSelectionType":"SPECIFIC","providers":[{"type":"OKTA"}]}} |
+----------------------+---------------+--------------+-----------------------------------------------------------------------+

Time: 0.7s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) okta_idp_discovery_policy.okta_admin: Time: 0.6s. Fetched: 1. Hydrates: 1.

> select 
  name,
  r -> 'PolicyRule' ->> 'type'  as policy_name,
  r -> 'PolicyRule' ->> 'name'  as policy_type,
  r -> 'Actions' as policy_actions
from 
  okta_admin.okta_authentication_policy,
  jsonb_array_elements(rules) as r
+-------------------------+---------------+------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name                    | policy_name   | policy_type                  | policy_actions                                                                                                                                                                                                           |
+-------------------------+---------------+------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Okta Browser Plugin     | ACCESS_POLICY | Catch-all Rule               | {"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","reauthenticateIn":"PT12H","type":"ASSURANCE"}}}                                                                                                 |
| Any two factors         | ACCESS_POLICY | Catch-all Rule               | {"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","reauthenticateIn":"PT12H","type":"ASSURANCE"}}}                                                                                                 |
| Okta Agent Registration | ACCESS_POLICY | Catch-all Rule               | {"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","reauthenticateIn":"PT12H","type":"ASSURANCE"}}}                                                                                                 |
| Okta Dashboard          | ACCESS_POLICY | Free trial org password Rule | {"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"required":true,"types":["password"]}}],"factorMode":"1FA","reauthenticateIn":"PT12H","type":"ASSURANCE"}}}                            |
| Okta Dashboard          | ACCESS_POLICY | Catch-all Rule               | {"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","reauthenticateIn":"PT12H","type":"ASSURANCE"}}}                                                                                                 |
| Okta Admin Console      | ACCESS_POLICY | Free trial org password Rule | {"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"required":true,"types":["password"]}}],"factorMode":"1FA","reauthenticateIn":"PT12H","type":"ASSURANCE"}}}                            |
| Okta Admin Console      | ACCESS_POLICY | Catch-all Rule               | {"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"reauthenticateIn":"PT12H","required":true,"types":["password"]}}],"factorMode":"2FA","reauthenticateIn":"PT12H","type":"ASSURANCE"}}} |
+-------------------------+---------------+------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

Time: 0.7s. Rows returned: 7. Rows fetched: 5. Hydrate calls: 5.

Scans:
  1) okta_authentication_policy.okta_admin: Time: 0.6s. Fetched: 5. Hydrates: 5.

```

## Classic Engine:

```
> select 
  name,
  r -> 'PolicyRule' ->> 'type'  as policy_name,
  r -> 'PolicyRule' ->> 'name'  as policy_type,
  r -> 'Actions' as policy_actions
from 
  okta_idp_discovery_policy,
  jsonb_array_elements(rules) as r
+----------------------+---------------+--------------+-----------------------------------------+
| name                 | policy_name   | policy_type  | policy_actions                          |
+----------------------+---------------+--------------+-----------------------------------------+
| Idp Discovery Policy | IDP_DISCOVERY | Default Rule | {"idp":{"providers":[{"type":"OKTA"}]}} |
+----------------------+---------------+--------------+-----------------------------------------+

Time: 1.5s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) okta_idp_discovery_policy.okta: Time: 1.4s. Fetched: 1. Hydrates: 1.

> select 
  name,
  r -> 'PolicyRule' ->> 'type'  as policy_name,
  r -> 'PolicyRule' ->> 'name'  as policy_type,
  r -> 'Actions' as policy_actions
from 
  okta_password_policy,
  jsonb_array_elements(rules) as r
+----------------+-------------+--------------+---------------------------------------------------------------------------------------------------------------------------+
| name           | policy_name | policy_type  | policy_actions                                                                                                            |
+----------------+-------------+--------------+---------------------------------------------------------------------------------------------------------------------------+
| Default Policy | PASSWORD    | Default Rule | {"passwordChange":{"access":"ALLOW"},"selfServicePasswordReset":{"access":"ALLOW"},"selfServiceUnlock":{"access":"DENY"}} |
+----------------+-------------+--------------+---------------------------------------------------------------------------------------------------------------------------+

Time: 0.6s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) okta_password_policy.okta: Time: 0.5s. Fetched: 1. Hydrates: 1.

>   select 
  name,
  r -> 'PolicyRule' ->> 'type'  as policy_name,
  r -> 'PolicyRule' ->> 'name'  as policy_type,
  r -> 'Actions' as policy_actions
from 
  okta_signon_policy,
  jsonb_array_elements(rules) as r
+----------------+-------------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name           | policy_name | policy_type  | policy_actions                                                                                                                                                                                                       |
+----------------+-------------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Default Policy | SIGN_ON     | Default Rule | {"signon":{"access":"ALLOW","primaryFactor":"PASSWORD_IDP","rememberDeviceByDefault":false,"requireFactor":false,"session":{"maxSessionIdleMinutes":120,"maxSessionLifetimeMinutes":0,"usePersistentCookie":false}}} |
+----------------+-------------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

Time: 0.6s. Rows returned: 1. Rows fetched: 3. Hydrate calls: 3.

Scans:
  1) okta_signon_policy.okta: Time: 0.5s. Fetched: 3. Hydrates: 3.


```
</details>
