### PR TITLE
Add table okta_group_rule. Closes #148

### DIFF
--- a/docs/tables/okta_group_rule.md
+++ b/docs/tables/okta_group_rule.md
@@ -14,7 +14,6 @@ The `okta_group_rule` table provides insights into group rules within Okta. As a
 ## Examples
 
 ### Basic info
-
 Explore the basic information about group rules in Okta to understand their purpose and configuration. This is useful for managing access controls and implementing security policies.
 
 ```sql+postgres
@@ -42,7 +41,6 @@ from
 ```
 
 ### List group rules without assignment changes for more than 30 days
-
 Determine the group rules that have not undergone assignment alterations in over a month. This could be useful for identifying inactive or stagnant group rules and assessing the need for assignment reviews or updates.
 
 ```sql+postgres
@@ -70,7 +68,6 @@ where
 ```
 
 ### List active group rules
-
 Retrieve group rules with the status 'ACTIVE' to identify active group rules and ensure that they are correctly configured. This is useful for managing access control and verifying the consistency of group rule assignments.
 
 ```sql+postgres
@@ -98,7 +95,6 @@ where
 ```
 
 ### List group rules with specific group membership actions
-
 This query retrieves Okta group rules, including the name, ID, status, and conditions, while filtering by specific group membership actions. This is useful for identifying group rules that assign users to specific groups.
 
 ```sql+postgres

--- a/docs/tables/okta_group_rule.md
+++ b/docs/tables/okta_group_rule.md
@@ -69,7 +69,7 @@ where
   last_updated < strftime('%s', 'now') - 30*24*60*60;
 ```
 
-### List group rules with status 'ACTIVE'
+### List active group rules
 
 Retrieve group rules with the status 'ACTIVE' to identify active group rules and ensure that they are correctly configured. This is useful for managing access control and verifying the consistency of group rule assignments.
 

--- a/docs/tables/okta_group_rule.md
+++ b/docs/tables/okta_group_rule.md
@@ -1,0 +1,145 @@
+---
+title: "Steampipe Table: okta_group_rule - Query Okta Group Rules using SQL"
+description: "Allows users to query Okta Group Rules, specifically the group rule details, providing insights into group rule assignments and access control."
+---
+
+# Table: okta_group_rule - Query Okta Group Rules using SQL
+
+Okta Group Rules are a collection of rules defined in the Okta service. They provide a way to manage group rules and their access to applications and resources. Group Rules are central to the role-based access control (RBAC) model in Okta, and they can be used for assigning roles and permissions.
+
+## Table Usage Guide
+
+The `okta_group_rule` table provides insights into group rules within Okta. As an IT administrator, explore group rule-specific details through this table, including group rule profile, type, and associated groups. Utilize it to manage access control, identify group rules with specific roles, and verify the consistency of group rule assignments.
+
+## Examples
+
+### Basic info
+
+Explore the basic information about group rules in Okta to understand their purpose and configuration. This is useful for managing access controls and implementing security policies.
+
+```sql+postgres
+select
+  name,
+  id,
+  status,
+  actions,
+  last_updated,
+  jsonb_pretty(conditions) as conditions
+from
+  okta_group_rule;
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  status,
+  actions,
+  last_updated,
+  conditions
+from
+  okta_group_rule;
+```
+
+### List group rules without assignment changes for more than 30 days
+
+Determine the group rules that have not undergone assignment alterations in over a month. This could be useful for identifying inactive or stagnant group rules and assessing the need for assignment reviews or updates.
+
+```sql+postgres
+select
+  name,
+  id,
+  status,
+  last_updated
+from
+  okta_group_rule
+where
+  last_updated < current_timestamp - interval '30 days';
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  status,
+  last_updated
+from
+  okta_group_rule
+where
+  last_updated < strftime('%s', 'now') - 30*24*60*60;
+```
+
+### List group rules with status 'ACTIVE'
+
+```sql+postgres
+select
+  name,
+  id,
+  status,
+  jsonb_pretty(conditions) as conditions
+from
+  okta_group_rule
+where
+  status = 'ACTIVE';
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  status,
+  conditions
+from  
+  okta_group_rule
+where
+  status = 'ACTIVE';
+```
+
+### List group rules with specific group membership actions
+
+This query retrieves Okta group rules, including the name, ID, status, and conditions, while filtering by specific group membership actions. This is useful for identifying group rules that assign users to specific groups.
+
+```sql+postgres
+with expanded_actions as (
+  select
+    name,
+    id,
+    status,
+    jsonb_pretty(conditions) as conditions,
+    jsonb_array_elements_text(actions->'assignUserToGroups'->'groupIds') as group_id
+  from
+    okta_group_rule
+)
+select
+  name,
+  id,
+  status,
+  conditions
+from
+  expanded_actions
+where
+  group_id = '00gl0xw4khfR4h5qJ5d7';
+```
+
+```sql+sqlite
+with expanded_actions as (
+  select
+    name,
+    id,
+    status,
+    json(conditions) as conditions,
+    json_each.value as group_id
+  from
+    okta_group_rule,
+    json_each(actions->'$.assignUserToGroups.groupIds')
+)
+select
+  name,
+  id,
+  status,
+  conditions
+from
+  expanded_actions
+where
+  group_id = '00gl0xw4khfR4h5qJ5d7';
+```

--- a/docs/tables/okta_group_rule.md
+++ b/docs/tables/okta_group_rule.md
@@ -71,6 +71,8 @@ where
 
 ### List group rules with status 'ACTIVE'
 
+Retrieve group rules with the status 'ACTIVE' to identify active group rules and ensure that they are correctly configured. This is useful for managing access control and verifying the consistency of group rule assignments.
+
 ```sql+postgres
 select
   name,

--- a/okta/plugin.go
+++ b/okta/plugin.go
@@ -32,6 +32,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"okta_device":                tableOktaDevice(),
 			"okta_factor":                tableOktaFactor(),
 			"okta_group":                 tableOktaGroup(),
+			"okta_group_rule":            tableOktaGroupRule(),
 			"okta_idp_discovery_policy":  tableOktaIdpDiscoveryPolicy(),
 			"okta_mfa_policy":            tableOktaMfaPolicy(),
 			"okta_network_zone":          tableOktaNetworkZone(),

--- a/okta/table_okta_group_rule.go
+++ b/okta/table_okta_group_rule.go
@@ -47,7 +47,7 @@ func listOktaGroupRules(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	logger := plugin.Logger(ctx)
 	client, err := Connect(ctx, d)
 	if err != nil {
-		logger.Error("listOktaGroupRules", "connection_error", err)
+		logger.Error("okta_group_rule.listOktaGroupRules", "connection_error", err)
 		return nil, err
 	}
 
@@ -69,7 +69,7 @@ func listOktaGroupRules(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	// Fetch group rules
 	groupRules, resp, err := client.Group.ListGroupRules(ctx, &input)
 	if err != nil {
-		logger.Error("listOktaGroupRules", "list_group_rules_error", err)
+		logger.Error("okta_group_rule.listOktaGroupRules", "api_error", err)
 		if strings.Contains(err.Error(), "Not found") {
 			return nil, nil
 		}
@@ -90,7 +90,7 @@ func listOktaGroupRules(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		var nextGroupRuleSet []*okta.GroupRule
 		resp, err = resp.Next(ctx, &nextGroupRuleSet)
 		if err != nil {
-			logger.Error("listOktaGroupRules", "list_group_rules_paging_error", err)
+			logger.Error("okta_group_rule.listOktaGroupRules", "api_paging_error", err)
 			return nil, err
 		}
 		for _, group_rule := range nextGroupRuleSet {
@@ -110,7 +110,6 @@ func listOktaGroupRules(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 
 func getOktaGroupRule(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
-	logger.Trace("getOktaGroupRule")
 
 	// Retrieve the rule ID from the query or hydrate data
 	var ruleId string
@@ -126,14 +125,14 @@ func getOktaGroupRule(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 	client, err := Connect(ctx, d)
 	if err != nil {
-		logger.Error("getOktaGroupRule", "connection_error", err)
+		logger.Error("okta_group_rule.getOktaGroupRule", "connection_error", err)
 		return nil, err
 	}
 
 	// Fetch the group rule by ID
 	groupRule, _, err := client.Group.GetGroupRule(ctx, ruleId, nil)
 	if err != nil {
-		logger.Error("getOktaGroupRule", "get_group_rule_error", err)
+		logger.Error("okta_group_rule.getOktaGroupRule", "api_error", err)
 		return nil, err
 	}
 

--- a/okta/table_okta_group_rule.go
+++ b/okta/table_okta_group_rule.go
@@ -23,7 +23,7 @@ func tableOktaGroupRule() *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listOktaGroupRules,
 		},
-		Columns: []*plugin.Column{
+		Columns: commonColumns( []*plugin.Column{
 			// Basic columns
 			{Name: "id", Type: proto.ColumnType_STRING, Description: "Unique identifier of the group rule."},
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the group rule."},
@@ -37,7 +37,7 @@ func tableOktaGroupRule() *plugin.Table {
 
 			// Steampipe-specific
 			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: "Title of the group rule."},
-		},
+		}),
 	}
 }
 

--- a/okta/table_okta_group_rule.go
+++ b/okta/table_okta_group_rule.go
@@ -2,7 +2,6 @@ package okta
 
 import (
 	"context"
-	"strings"
 
 	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
@@ -22,6 +21,7 @@ func tableOktaGroupRule() *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listOktaGroupRules,
+			ShouldIgnoreError: isNotFoundError([]string{"Not found"}),
 		},
 		Columns: commonColumns( []*plugin.Column{
 			// Basic columns
@@ -70,9 +70,6 @@ func listOktaGroupRules(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	groupRules, resp, err := client.Group.ListGroupRules(ctx, &input)
 	if err != nil {
 		logger.Error("okta_group_rule.listOktaGroupRules", "api_error", err)
-		if strings.Contains(err.Error(), "Not found") {
-			return nil, nil
-		}
 		return nil, err
 	}
 

--- a/okta/table_okta_group_rule.go
+++ b/okta/table_okta_group_rule.go
@@ -1,0 +1,105 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func tableOktaGroupRule() *plugin.Table {
+	return &plugin.Table{
+		Name:        "okta_group_rule",
+		Description: "Retrieve group rules for Okta. Group rules define conditions and actions for automating group membership.",
+		Get: &plugin.GetConfig{
+			Hydrate:           getOktaGroupRule,
+			KeyColumns:        plugin.SingleColumn("id"),
+			ShouldIgnoreError: isNotFoundError([]string{"Not found"}),
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listOktaGroupRules,
+		},
+		Columns: []*plugin.Column{
+			// Basic columns
+			{Name: "id", Type: proto.ColumnType_STRING, Description: "Unique identifier of the group rule."},
+			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the group rule."},
+			{Name: "status", Type: proto.ColumnType_STRING, Description: "Status of the group rule (e.g., ACTIVE, INACTIVE)."},
+			{Name: "created", Type: proto.ColumnType_TIMESTAMP, Description: "Timestamp when the group rule was created."},
+			{Name: "last_updated", Type: proto.ColumnType_TIMESTAMP, Description: "Timestamp when the group rule was last updated."},
+
+			// JSON columns
+			{Name: "conditions", Type: proto.ColumnType_JSON, Description: "Conditions that trigger this group rule."},
+			{Name: "actions", Type: proto.ColumnType_JSON, Description: "Actions performed when the rule conditions are met."},
+
+			// Steampipe-specific
+			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name"), Description: "Title of the group rule."},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listOktaGroupRules(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("listOktaGroupRules")
+
+	client, err := Connect(ctx, d)
+	if err != nil {
+		logger.Error("listOktaGroupRules", "connection_error", err)
+		return nil, err
+	}
+
+	// Fetch group rules
+	groupRules, _, err := client.Group.ListGroupRules(ctx, nil)
+	if err != nil {
+		logger.Error("listOktaGroupRules", "list_error", err)
+		return nil, err
+	}
+
+	for _, rule := range groupRules {
+		d.StreamListItem(ctx, rule)
+
+		// Exit if the context is canceled
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+
+	return nil, nil
+}
+
+//// GET FUNCTION
+
+func getOktaGroupRule(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("getOktaGroupRule")
+
+	// Retrieve the rule ID from the query or hydrate data
+	var ruleId string
+	if h.Item != nil {
+		ruleId = h.Item.(*okta.GroupRule).Id
+	} else {
+		ruleId = d.EqualsQuals["id"].GetStringValue()
+	}
+
+	if ruleId == "" {
+		return nil, nil
+	}
+
+	client, err := Connect(ctx, d)
+	if err != nil {
+		logger.Error("getOktaGroupRule", "connection_error", err)
+		return nil, err
+	}
+
+	// Fetch the group rule by ID
+	groupRule, _, err := client.Group.GetGroupRule(ctx, ruleId, nil)
+	if err != nil {
+		logger.Error("getOktaGroupRule", "get_error", err)
+		return nil, err
+	}
+
+	return groupRule, nil
+}

--- a/okta/table_okta_group_rule.go
+++ b/okta/table_okta_group_rule.go
@@ -103,7 +103,7 @@ func listOktaGroupRules(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	return nil, err
 }
 
-//// GET FUNCTION
+//// HYDRATE FUNCTION
 
 func getOktaGroupRule(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
select
  name,
  id,
  status,
  actions,
  last_updated,
  jsonb_pretty(conditions) as conditions
from
  okta_group_rule;
+---------+----------------------+----------+--------------------------------------------------------------+---------------------------+--------------------------------------------+
| name    | id                   | status   | actions                                                      | last_updated              | conditions                                 |
+---------+----------------------+----------+--------------------------------------------------------------+---------------------------+--------------------------------------------+
| test-pc | 0prl91im1oMp7Xsrw5d7 | INACTIVE | {"assignUserToGroups":{"groupIds":["00gl0xw4khfR4h5qJ5d7"]}} | 2024-11-19T16:33:21+05:30 | {                                          |
|         |                      |          |                                                              |                           |     "expression": {                        |
|         |                      |          |                                                              |                           |         "type": "urn:okta:expression:1.0", |
|         |                      |          |                                                              |                           |         "value": "user.login==\"qq\""      |
|         |                      |          |                                                              |                           |     }                                      |
|         |                      |          |                                                              |                           | }                                          |
| qwerty  | 0prl91iuolRGYZ6Y85d7 | INACTIVE | {"assignUserToGroups":{"groupIds":["00gl0xw4khfR4h5qJ5d7"]}} | 2024-11-19T16:34:59+05:30 | {                                          |
|         |                      |          |                                                              |                           |     "expression": {                        |
|         |                      |          |                                                              |                           |         "type": "urn:okta:expression:1.0", |
|         |                      |          |                                                              |                           |         "value": "user.login==\"aa\""      |
|         |                      |          |                                                              |                           |     }                                      |
|         |                      |          |                                                              |                           | }                                          |
+---------+----------------------+----------+--------------------------------------------------------------+---------------------------+--------------------------------------------+

select
  name,
  id,
  status,
  last_updated
from
  okta_group_rule
where
  last_updated < current_timestamp - interval '30 days';
+------+----+--------+--------------+
| name | id | status | last_updated |
+------+----+--------+--------------+
+------+----+--------+--------------+

select
  name,
  id,
  status,
  jsonb_pretty(conditions) as conditions
from
  okta_group_rule
where
  status = 'ACTIVE';
+------+----+--------+------------+
| name | id | status | conditions |
+------+----+--------+------------+
+------+----+--------+------------+

with expanded_actions as (
  select
    name,
    id,
    status,
    jsonb_pretty(conditions) as conditions,
    jsonb_array_elements_text(actions->'assignUserToGroups'->'groupIds') as group_id
  from
    okta_group_rule
)
select
  name,
  id,
  status,
  conditions
from
  expanded_actions
where
  group_id = '00gl0xw4khfR4h5qJ5d7';
+---------+----------------------+----------+--------------------------------------------+
| name    | id                   | status   | conditions                                 |
+---------+----------------------+----------+--------------------------------------------+
| test-pc | 0prl91im1oMp7Xsrw5d7 | INACTIVE | {                                          |
|         |                      |          |     "expression": {                        |
|         |                      |          |         "type": "urn:okta:expression:1.0", |
|         |                      |          |         "value": "user.login==\"qq\""      |
|         |                      |          |     }                                      |
|         |                      |          | }                                          |
| qwerty  | 0prl91iuolRGYZ6Y85d7 | INACTIVE | {                                          |
|         |                      |          |     "expression": {                        |
|         |                      |          |         "type": "urn:okta:expression:1.0", |
|         |                      |          |         "value": "user.login==\"aa\""      |
|         |                      |          |     }                                      |
|         |                      |          | }                                          |
+---------+----------------------+----------+--------------------------------------------+
```
</details>
