### PR TITLE
fix(docs): Include previously missing scope in plugin documentation Closes #178

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,7 @@ If using the Okta service application, the following scopes must be enabled for 
 - okta.users.read
 - okta.groups.read
 - okta.apps.read
+- okta.devices.read
 - okta.roles.read
 - okta.policies.read
 - okta.authorizationServers.read


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
